### PR TITLE
ADAPT-2142: Dismiss Button as its own component and Alert tweaks

### DIFF
--- a/dist/decanter-react.js
+++ b/dist/decanter-react.js
@@ -1119,6 +1119,10 @@ var alertTypes = ['info', 'warning', 'error', 'success'];
 var lightText = 'su-text-white hover:su-link-no-underline';
 var darkText = 'su-text-black su-link-black-true hover:su-link-no-underline';
 
+var dismissIconColors = ['black', 'white', 'unset'];
+var dismissIconOptions = ['x-circle', 'x', 'none'];
+var dismissIconTypes = ['solid', 'outline'];
+
 var buttonVariants = ['primary', 'secondary', 'none'];
 var buttonSizes = ['big', 'small', 'minimal'];
 var buttonTypes = ['button', 'submit', 'reset'];
@@ -1207,6 +1211,98 @@ Button.defaultProps = {
   ref: null
 };
 
+var SrOnlyText = function SrOnlyText(props) {
+  var _props$srText;
+
+  var txt = (_props$srText = props.srText) != null ? _props$srText : '(link is external)';
+  return /*#__PURE__*/React__default.createElement("span", {
+    className: "su-sr-only"
+  }, txt);
+};
+SrOnlyText.propTypes = {
+  srText: propTypes.string
+};
+SrOnlyText.defaultProps = {
+  srText: '(link is external)'
+};
+
+var DismissButton = function DismissButton(_ref) {
+  var _ref$classes = _ref.classes,
+      classes = _ref$classes === void 0 ? {} : _ref$classes,
+      text = _ref.text,
+      srText = _ref.srText,
+      color = _ref.color,
+      icon = _ref.icon,
+      iconType = _ref.iconType,
+      customIcon = _ref.customIcon,
+      onClick = _ref.onClick,
+      props = _objectWithoutPropertiesLoose(_ref, ["classes", "text", "srText", "color", "icon", "iconType", "customIcon", "onClick"]);
+
+  var levers = {};
+  var iconProps = {
+    height: 20,
+    width: 20
+  };
+
+  if (color && dismissIconColors.includes(color)) {
+    switch (color) {
+      case 'black':
+        levers.color = 'su-text-black hocus:su-text-black';
+        break;
+
+      case 'white':
+        levers.color = 'su-text-white hocus:su-text-white';
+        break;
+    }
+  }
+
+  var heroicon = '';
+
+  if (icon && dismissIconOptions.includes(icon)) {
+    heroicon = icon;
+  }
+
+  var heroiconType = 'solid';
+
+  if (iconType && dismissIconTypes.includes(iconType)) {
+    heroiconType = iconType;
+  }
+
+  var defaultIcon = /*#__PURE__*/React__default.createElement(Icon, _extends({
+    icon: heroicon,
+    type: heroiconType,
+    "aria-hidden": "true",
+    className: classes.icon
+  }, iconProps));
+  var dismissIcon = customIcon != null ? customIcon : defaultIcon;
+  return /*#__PURE__*/React__default.createElement(Button, _extends({
+    variant: "none",
+    size: "minimal",
+    className: clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display', levers.color, classes.wrapper),
+    onClick: onClick
+  }, props), text, srText && /*#__PURE__*/React__default.createElement(SrOnlyText, {
+    srText: ' ' + srText
+  }), dismissIcon);
+};
+DismissButton.propTypes = {
+  text: propTypes.string,
+  srText: propTypes.string,
+  color: propTypes.oneOf(dismissIconColors),
+  icon: propTypes.oneOf(dismissIconOptions),
+  iconType: propTypes.oneOf(dismissIconTypes),
+  customIcon: propTypes.element,
+  onClick: propTypes.func,
+  classes: propTypes.shape({
+    wrapper: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array]),
+    icon: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array])
+  })
+};
+DismissButton.defaultProps = {
+  color: 'black',
+  icon: 'x-circle',
+  iconType: 'solid'
+};
+
 var Alert = function Alert(_ref) {
   var _props$icon, _props$dismissBtn, _props$label, _props$label2;
 
@@ -1218,8 +1314,8 @@ var Alert = function Alert(_ref) {
 
   var levers = {};
   var iconProps = {
-    height: 24,
-    width: 24
+    height: 20,
+    width: 20
   };
 
   var _useState = React.useState(false),
@@ -1227,7 +1323,7 @@ var Alert = function Alert(_ref) {
       setDismissed = _useState[1];
 
   levers.wrapper = 'su-bg-foggy-light';
-  levers.dismiss = clsxd(darkText, 'hover:su-text-black focus:su-text-black');
+  levers.dismiss = 'black';
 
   if (props.isLargeIcon) {
     iconProps.height = 60;
@@ -1237,31 +1333,20 @@ var Alert = function Alert(_ref) {
   var defaultIcon = /*#__PURE__*/React__default.createElement(Icon, _extends({
     icon: "bell",
     type: "outline",
-    className: clsxd({
-      'su-inline-block': props.isIconTop
-    }, classes.icon)
+    "aria-hidden": "true",
+    className: classes.icon
   }, iconProps));
-
-  if (props.isLabelTop) {
-    levers.label = clsxd('su-rs-mb-neg1', {
-      'su-inline-block': !props.isIconTop
-    });
-    classes.icon = clsxd(classes.icon, 'su-inline-block');
-  }
-
-  if (props.isIconTop && !props.isLabelTop) {
-    levers.headerIcon = clsxd(levers.headerIcon, 'su-block su-rs-mb-neg1');
-  }
 
   if (props.type && alertTypes.includes(props.type)) {
     switch (props.type) {
       case 'success':
         levers.wrapper = 'su-bg-digital-green su-text-white su-link-white';
         levers.body = lightText;
-        levers.dismiss = lightText;
+        levers.dismiss = 'white';
         defaultIcon = /*#__PURE__*/React__default.createElement(Icon, _extends({
           icon: "check-circle",
           type: "solid",
+          "aria-hidden": "true",
           className: clsxd(classes.icon)
         }, iconProps));
         break;
@@ -1269,10 +1354,11 @@ var Alert = function Alert(_ref) {
       case 'warning':
         levers.wrapper = 'su-bg-illuminating-dark';
         levers.body = darkText;
-        levers.dismiss = clsxd(darkText, 'hover:su-text-black');
+        levers.dismiss = 'black';
         defaultIcon = /*#__PURE__*/React__default.createElement(Icon, _extends({
           icon: "exclamation-circle",
           type: "solid",
+          "aria-hidden": "true",
           className: clsxd(classes.icon)
         }, iconProps));
         break;
@@ -1280,10 +1366,11 @@ var Alert = function Alert(_ref) {
       case 'info':
         levers.wrapper = 'su-bg-digital-blue su-text-white su-link-white';
         levers.body = lightText;
-        levers.dismiss = lightText;
+        levers.dismiss = 'white';
         defaultIcon = /*#__PURE__*/React__default.createElement(Icon, _extends({
           icon: "information-circle",
           type: "solid",
+          "aria-hidden": "true",
           className: clsxd(classes.icon)
         }, iconProps));
         break;
@@ -1291,10 +1378,11 @@ var Alert = function Alert(_ref) {
       case 'error':
         levers.wrapper = 'su-bg-digital-red su-text-white su-link-white';
         levers.body = lightText;
-        levers.dismiss = lightText;
+        levers.dismiss = 'white';
         defaultIcon = /*#__PURE__*/React__default.createElement(Icon, _extends({
           icon: "ban",
           type: "solid",
+          "aria-hidden": "true",
           className: clsxd(classes.icon)
         }, iconProps));
         break;
@@ -1302,19 +1390,17 @@ var Alert = function Alert(_ref) {
   }
 
   var icon = (_props$icon = props.icon) != null ? _props$icon : defaultIcon;
-  var DefaultDismiss = /*#__PURE__*/React__default.createElement(Button, {
-    className: clsxd('su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest', levers.dismiss, classes.dismiss),
-    "aria-label": "Dismiss Alert",
+  var DefaultDismiss = /*#__PURE__*/React__default.createElement(DismissButton, {
+    text: "Dismiss",
     onClick: function onClick() {
       setDismissed(true);
     },
-    variant: "none",
-    size: "minimal"
-  }, "Dismiss ", /*#__PURE__*/React__default.createElement(Icon, {
-    icon: "x-circle",
-    type: "solid",
-    className: 'su-inline-block su-h-25 su-w-25'
-  }));
+    color: levers.dismiss,
+    classes: {
+      icon: 'su-ml-02em',
+      wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest su-mr-0 su-ml-auto'
+    }
+  });
   var dismissBtn = (_props$dismissBtn = props.dismissBtn) != null ? _props$dismissBtn : DefaultDismiss;
 
   if (isDismissed === true) {
@@ -1327,21 +1413,23 @@ var Alert = function Alert(_ref) {
   }, /*#__PURE__*/React__default.createElement("div", {
     className: clsxd('su-cc su-flex su-flex-wrap su-rs-py-1 sm:su-items-center', levers.container, classes.container)
   }, props.hasDismiss && /*#__PURE__*/React__default.createElement("div", {
-    className: clsxd('su-order-3 su-rs-ml-1 su-items-end su-flex-shrink su-text-right su-w-full sm:su-w-auto', levers.dismissWrapper, classes.dismissWrapper)
-  }, dismissBtn), /*#__PURE__*/React__default.createElement("div", {
-    className: clsxd('su-order-1 su-rs-mr-1 su-flex su-flex-shrink su-items-center su-mb-4 su-w-full su-pb-10 md:su-w-max', levers.headerWrapper, classes.headerWrapper)
+    className: clsxd('su-order-3 su-rs-ml-1 su-mt-15 sm:su-mt-0 su-items-center su-flex-shrink su-text-right su-w-full sm:su-w-auto', levers.dismissWrapper, classes.dismissWrapper)
+  }, dismissBtn), (props.hasIcon && !props.isIconTop || props.hasLabel && !props.isLabelTop) && /*#__PURE__*/React__default.createElement("div", {
+    className: clsxd('su-order-1 su-rs-mr-1 su-mb-15 md:su-mb-0 su-flex su-flex-shrink su-items-center su-w-full md:su-w-max', levers.headerWrapper, classes.headerWrapper)
   }, props.hasIcon && !props.isIconTop && /*#__PURE__*/React__default.createElement("span", {
     className: clsxd('su-mr-5 su-inline-block', levers.headerIcon, classes.headerIcon)
   }, icon), props.hasLabel && !props.isLabelTop && /*#__PURE__*/React__default.createElement("span", {
     className: clsxd('su-inline-block su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)
-  }, (_props$label = props.label) != null ? _props$label : 'Information')), /*#__PURE__*/React__default.createElement("div", {
+  }, (_props$label = props.label) != null ? _props$label : 'Alert:')), /*#__PURE__*/React__default.createElement("div", {
     className: clsxd('su-order-2 su-flex-1 su-flex-grow', levers.bodyWrapper, classes.bodyWrapper)
+  }, (props.hasIcon && props.isIconTop || props.hasLabel && props.isLabelTop) && /*#__PURE__*/React__default.createElement("div", {
+    className: "su-flex su-items-center su-rs-mb-0"
   }, props.hasIcon && props.isIconTop && /*#__PURE__*/React__default.createElement("span", {
-    className: clsxd('su-mr-5 su-text-left su-ml-0', levers.headerIcon, classes.headerIcon)
-  }, icon), props.hasLabel && props.isLabelTop && /*#__PURE__*/React__default.createElement("span", {
-    className: clsxd('su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)
-  }, (_props$label2 = props.label) != null ? _props$label2 : 'Information'), props.heading && /*#__PURE__*/React__default.createElement("h3", {
-    className: clsxd('su-type-2 su-mb-03em', levers.bodyHeading, classes.bodyHeading)
+    className: clsxd('su-inline-block su-mr-5 su-text-left su-ml-0', levers.headerIcon, classes.headerIcon)
+  }, icon), props.hasLabel && props.isLabelTop && /*#__PURE__*/React__default.createElement("div", {
+    className: clsxd('su-inline-block su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)
+  }, (_props$label2 = props.label) != null ? _props$label2 : 'Alert:')), props.heading && /*#__PURE__*/React__default.createElement("h3", {
+    className: clsxd('su-type-1 su-rs-mb-neg1', levers.bodyHeading, classes.bodyHeading)
   }, props.heading), /*#__PURE__*/React__default.createElement("div", {
     className: clsxd('su-text-normal', levers.body, classes.body)
   }, children), props.footer && /*#__PURE__*/React__default.createElement("div", {
@@ -1808,21 +1896,6 @@ Logo.defaultProps = {
   color: 'cardinal-red',
   type: 'short',
   isLink: true
-};
-
-var SrOnlyText = function SrOnlyText(props) {
-  var _props$srText;
-
-  var txt = (_props$srText = props.srText) != null ? _props$srText : '(link is external)';
-  return /*#__PURE__*/React__default.createElement("span", {
-    className: "su-sr-only"
-  }, txt);
-};
-SrOnlyText.propTypes = {
-  srText: propTypes.string
-};
-SrOnlyText.defaultProps = {
-  srText: '(link is external)'
 };
 
 var GlobalFooter = function GlobalFooter(_ref) {
@@ -2381,6 +2454,7 @@ var StyledLink = function StyledLink(props) {
 exports.Alert = Alert;
 exports.Button = Button;
 exports.Container = Container;
+exports.DismissButton = DismissButton;
 exports.FlexBox = FlexBox;
 exports.FlexCell = FlexCell;
 exports.GlobalFooter = GlobalFooter;

--- a/dist/decanter-react.js
+++ b/dist/decanter-react.js
@@ -1233,15 +1233,16 @@ var DismissButton = function DismissButton(_ref) {
       color = _ref.color,
       icon = _ref.icon,
       iconType = _ref.iconType,
+      iconSize = _ref.iconSize,
       iconProps = _ref.iconProps,
       customIcon = _ref.customIcon,
       onClick = _ref.onClick,
-      props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconProps", "customIcon", "onClick"]);
+      props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconSize", "iconProps", "customIcon", "onClick"]);
 
   var levers = {};
   iconProps = Object.assign({
-    height: 20,
-    width: 20
+    height: iconSize != null ? iconSize : 20,
+    width: iconSize != null ? iconSize : 20
   }, _extends({}, iconProps));
 
   if (color && dismissIconColors.includes(color)) {
@@ -1292,6 +1293,7 @@ DismissButton.propTypes = {
   customIcon: propTypes.element,
   onClick: propTypes.func,
   iconProps: propTypes.object,
+  iconSize: propTypes.number,
   className: propTypes.oneOfType([propTypes.string, propTypes.array, propTypes.object])
 };
 DismissButton.defaultProps = {

--- a/dist/decanter-react.js
+++ b/dist/decanter-react.js
@@ -1227,22 +1227,22 @@ SrOnlyText.defaultProps = {
 };
 
 var DismissButton = function DismissButton(_ref) {
-  var _ref$classes = _ref.classes,
-      classes = _ref$classes === void 0 ? {} : _ref$classes,
+  var className = _ref.className,
       text = _ref.text,
       srText = _ref.srText,
       color = _ref.color,
       icon = _ref.icon,
       iconType = _ref.iconType,
+      iconProps = _ref.iconProps,
       customIcon = _ref.customIcon,
       onClick = _ref.onClick,
-      props = _objectWithoutPropertiesLoose(_ref, ["classes", "text", "srText", "color", "icon", "iconType", "customIcon", "onClick"]);
+      props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconProps", "customIcon", "onClick"]);
 
   var levers = {};
-  var iconProps = {
+  iconProps = Object.assign({
     height: 20,
     width: 20
-  };
+  }, _extends({}, iconProps));
 
   if (color && dismissIconColors.includes(color)) {
     switch (color) {
@@ -1271,14 +1271,13 @@ var DismissButton = function DismissButton(_ref) {
   var defaultIcon = /*#__PURE__*/React__default.createElement(Icon, _extends({
     icon: heroicon,
     type: heroiconType,
-    "aria-hidden": "true",
-    className: classes.icon
+    "aria-hidden": "true"
   }, iconProps));
   var dismissIcon = customIcon != null ? customIcon : defaultIcon;
   return /*#__PURE__*/React__default.createElement(Button, _extends({
     variant: "none",
     size: "minimal",
-    className: clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display', levers.color, classes.wrapper),
+    className: clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display', levers.color, className),
     onClick: onClick
   }, props), text, srText && /*#__PURE__*/React__default.createElement(SrOnlyText, {
     srText: ' ' + srText
@@ -1292,10 +1291,8 @@ DismissButton.propTypes = {
   iconType: propTypes.oneOf(dismissIconTypes),
   customIcon: propTypes.element,
   onClick: propTypes.func,
-  classes: propTypes.shape({
-    wrapper: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array]),
-    icon: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array])
-  })
+  iconProps: propTypes.object,
+  className: propTypes.oneOfType([propTypes.string, propTypes.array, propTypes.object])
 };
 DismissButton.defaultProps = {
   color: 'black',
@@ -1347,7 +1344,7 @@ var Alert = function Alert(_ref) {
           icon: "check-circle",
           type: "solid",
           "aria-hidden": "true",
-          className: clsxd(classes.icon)
+          className: classes.icon
         }, iconProps));
         break;
 
@@ -1359,7 +1356,7 @@ var Alert = function Alert(_ref) {
           icon: "exclamation-circle",
           type: "solid",
           "aria-hidden": "true",
-          className: clsxd(classes.icon)
+          className: classes.icon
         }, iconProps));
         break;
 
@@ -1371,7 +1368,7 @@ var Alert = function Alert(_ref) {
           icon: "information-circle",
           type: "solid",
           "aria-hidden": "true",
-          className: clsxd(classes.icon)
+          className: classes.icon
         }, iconProps));
         break;
 
@@ -1383,7 +1380,7 @@ var Alert = function Alert(_ref) {
           icon: "ban",
           type: "solid",
           "aria-hidden": "true",
-          className: clsxd(classes.icon)
+          className: classes.icon
         }, iconProps));
         break;
     }
@@ -1396,9 +1393,9 @@ var Alert = function Alert(_ref) {
       setDismissed(true);
     },
     color: levers.dismiss,
-    classes: {
-      icon: 'su-ml-02em',
-      wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest su-mr-0 su-ml-auto'
+    className: "su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest su-mr-0 su-ml-auto",
+    iconProps: {
+      className: 'su-ml-02em'
     }
   });
   var dismissBtn = (_props$dismissBtn = props.dismissBtn) != null ? _props$dismissBtn : DefaultDismiss;

--- a/dist/decanter-react.js
+++ b/dist/decanter-react.js
@@ -1240,10 +1240,10 @@ var DismissButton = function DismissButton(_ref) {
       props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconSize", "iconProps", "customIcon", "onClick"]);
 
   var levers = {};
-  iconProps = Object.assign({
+  iconProps = _extends({
     height: iconSize != null ? iconSize : 20,
     width: iconSize != null ? iconSize : 20
-  }, _extends({}, iconProps));
+  }, iconProps);
 
   if (color && dismissIconColors.includes(color)) {
     switch (color) {

--- a/dist/decanter-react.modern.js
+++ b/dist/decanter-react.modern.js
@@ -1116,6 +1116,10 @@ var alertTypes = ['info', 'warning', 'error', 'success'];
 var lightText = 'su-text-white hover:su-link-no-underline';
 var darkText = 'su-text-black su-link-black-true hover:su-link-no-underline';
 
+var dismissIconColors = ['black', 'white', 'unset'];
+var dismissIconOptions = ['x-circle', 'x', 'none'];
+var dismissIconTypes = ['solid', 'outline'];
+
 var buttonVariants = ['primary', 'secondary', 'none'];
 var buttonSizes = ['big', 'small', 'minimal'];
 var buttonTypes = ['button', 'submit', 'reset'];
@@ -1204,6 +1208,98 @@ Button.defaultProps = {
   ref: null
 };
 
+var SrOnlyText = function SrOnlyText(props) {
+  var _props$srText;
+
+  var txt = (_props$srText = props.srText) != null ? _props$srText : '(link is external)';
+  return /*#__PURE__*/React.createElement("span", {
+    className: "su-sr-only"
+  }, txt);
+};
+SrOnlyText.propTypes = {
+  srText: propTypes.string
+};
+SrOnlyText.defaultProps = {
+  srText: '(link is external)'
+};
+
+var DismissButton = function DismissButton(_ref) {
+  var _ref$classes = _ref.classes,
+      classes = _ref$classes === void 0 ? {} : _ref$classes,
+      text = _ref.text,
+      srText = _ref.srText,
+      color = _ref.color,
+      icon = _ref.icon,
+      iconType = _ref.iconType,
+      customIcon = _ref.customIcon,
+      onClick = _ref.onClick,
+      props = _objectWithoutPropertiesLoose(_ref, ["classes", "text", "srText", "color", "icon", "iconType", "customIcon", "onClick"]);
+
+  var levers = {};
+  var iconProps = {
+    height: 20,
+    width: 20
+  };
+
+  if (color && dismissIconColors.includes(color)) {
+    switch (color) {
+      case 'black':
+        levers.color = 'su-text-black hocus:su-text-black';
+        break;
+
+      case 'white':
+        levers.color = 'su-text-white hocus:su-text-white';
+        break;
+    }
+  }
+
+  var heroicon = '';
+
+  if (icon && dismissIconOptions.includes(icon)) {
+    heroicon = icon;
+  }
+
+  var heroiconType = 'solid';
+
+  if (iconType && dismissIconTypes.includes(iconType)) {
+    heroiconType = iconType;
+  }
+
+  var defaultIcon = /*#__PURE__*/React.createElement(Icon, _extends({
+    icon: heroicon,
+    type: heroiconType,
+    "aria-hidden": "true",
+    className: classes.icon
+  }, iconProps));
+  var dismissIcon = customIcon != null ? customIcon : defaultIcon;
+  return /*#__PURE__*/React.createElement(Button, _extends({
+    variant: "none",
+    size: "minimal",
+    className: clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display', levers.color, classes.wrapper),
+    onClick: onClick
+  }, props), text, srText && /*#__PURE__*/React.createElement(SrOnlyText, {
+    srText: ' ' + srText
+  }), dismissIcon);
+};
+DismissButton.propTypes = {
+  text: propTypes.string,
+  srText: propTypes.string,
+  color: propTypes.oneOf(dismissIconColors),
+  icon: propTypes.oneOf(dismissIconOptions),
+  iconType: propTypes.oneOf(dismissIconTypes),
+  customIcon: propTypes.element,
+  onClick: propTypes.func,
+  classes: propTypes.shape({
+    wrapper: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array]),
+    icon: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array])
+  })
+};
+DismissButton.defaultProps = {
+  color: 'black',
+  icon: 'x-circle',
+  iconType: 'solid'
+};
+
 var Alert = function Alert(_ref) {
   var _props$icon, _props$dismissBtn, _props$label, _props$label2;
 
@@ -1215,8 +1311,8 @@ var Alert = function Alert(_ref) {
 
   var levers = {};
   var iconProps = {
-    height: 24,
-    width: 24
+    height: 20,
+    width: 20
   };
 
   var _useState = useState(false),
@@ -1224,7 +1320,7 @@ var Alert = function Alert(_ref) {
       setDismissed = _useState[1];
 
   levers.wrapper = 'su-bg-foggy-light';
-  levers.dismiss = clsxd(darkText, 'hover:su-text-black focus:su-text-black');
+  levers.dismiss = 'black';
 
   if (props.isLargeIcon) {
     iconProps.height = 60;
@@ -1234,31 +1330,20 @@ var Alert = function Alert(_ref) {
   var defaultIcon = /*#__PURE__*/React.createElement(Icon, _extends({
     icon: "bell",
     type: "outline",
-    className: clsxd({
-      'su-inline-block': props.isIconTop
-    }, classes.icon)
+    "aria-hidden": "true",
+    className: classes.icon
   }, iconProps));
-
-  if (props.isLabelTop) {
-    levers.label = clsxd('su-rs-mb-neg1', {
-      'su-inline-block': !props.isIconTop
-    });
-    classes.icon = clsxd(classes.icon, 'su-inline-block');
-  }
-
-  if (props.isIconTop && !props.isLabelTop) {
-    levers.headerIcon = clsxd(levers.headerIcon, 'su-block su-rs-mb-neg1');
-  }
 
   if (props.type && alertTypes.includes(props.type)) {
     switch (props.type) {
       case 'success':
         levers.wrapper = 'su-bg-digital-green su-text-white su-link-white';
         levers.body = lightText;
-        levers.dismiss = lightText;
+        levers.dismiss = 'white';
         defaultIcon = /*#__PURE__*/React.createElement(Icon, _extends({
           icon: "check-circle",
           type: "solid",
+          "aria-hidden": "true",
           className: clsxd(classes.icon)
         }, iconProps));
         break;
@@ -1266,10 +1351,11 @@ var Alert = function Alert(_ref) {
       case 'warning':
         levers.wrapper = 'su-bg-illuminating-dark';
         levers.body = darkText;
-        levers.dismiss = clsxd(darkText, 'hover:su-text-black');
+        levers.dismiss = 'black';
         defaultIcon = /*#__PURE__*/React.createElement(Icon, _extends({
           icon: "exclamation-circle",
           type: "solid",
+          "aria-hidden": "true",
           className: clsxd(classes.icon)
         }, iconProps));
         break;
@@ -1277,10 +1363,11 @@ var Alert = function Alert(_ref) {
       case 'info':
         levers.wrapper = 'su-bg-digital-blue su-text-white su-link-white';
         levers.body = lightText;
-        levers.dismiss = lightText;
+        levers.dismiss = 'white';
         defaultIcon = /*#__PURE__*/React.createElement(Icon, _extends({
           icon: "information-circle",
           type: "solid",
+          "aria-hidden": "true",
           className: clsxd(classes.icon)
         }, iconProps));
         break;
@@ -1288,10 +1375,11 @@ var Alert = function Alert(_ref) {
       case 'error':
         levers.wrapper = 'su-bg-digital-red su-text-white su-link-white';
         levers.body = lightText;
-        levers.dismiss = lightText;
+        levers.dismiss = 'white';
         defaultIcon = /*#__PURE__*/React.createElement(Icon, _extends({
           icon: "ban",
           type: "solid",
+          "aria-hidden": "true",
           className: clsxd(classes.icon)
         }, iconProps));
         break;
@@ -1299,19 +1387,17 @@ var Alert = function Alert(_ref) {
   }
 
   var icon = (_props$icon = props.icon) != null ? _props$icon : defaultIcon;
-  var DefaultDismiss = /*#__PURE__*/React.createElement(Button, {
-    className: clsxd('su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest', levers.dismiss, classes.dismiss),
-    "aria-label": "Dismiss Alert",
+  var DefaultDismiss = /*#__PURE__*/React.createElement(DismissButton, {
+    text: "Dismiss",
     onClick: function onClick() {
       setDismissed(true);
     },
-    variant: "none",
-    size: "minimal"
-  }, "Dismiss ", /*#__PURE__*/React.createElement(Icon, {
-    icon: "x-circle",
-    type: "solid",
-    className: 'su-inline-block su-h-25 su-w-25'
-  }));
+    color: levers.dismiss,
+    classes: {
+      icon: 'su-ml-02em',
+      wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest su-mr-0 su-ml-auto'
+    }
+  });
   var dismissBtn = (_props$dismissBtn = props.dismissBtn) != null ? _props$dismissBtn : DefaultDismiss;
 
   if (isDismissed === true) {
@@ -1324,21 +1410,23 @@ var Alert = function Alert(_ref) {
   }, /*#__PURE__*/React.createElement("div", {
     className: clsxd('su-cc su-flex su-flex-wrap su-rs-py-1 sm:su-items-center', levers.container, classes.container)
   }, props.hasDismiss && /*#__PURE__*/React.createElement("div", {
-    className: clsxd('su-order-3 su-rs-ml-1 su-items-end su-flex-shrink su-text-right su-w-full sm:su-w-auto', levers.dismissWrapper, classes.dismissWrapper)
-  }, dismissBtn), /*#__PURE__*/React.createElement("div", {
-    className: clsxd('su-order-1 su-rs-mr-1 su-flex su-flex-shrink su-items-center su-mb-4 su-w-full su-pb-10 md:su-w-max', levers.headerWrapper, classes.headerWrapper)
+    className: clsxd('su-order-3 su-rs-ml-1 su-mt-15 sm:su-mt-0 su-items-center su-flex-shrink su-text-right su-w-full sm:su-w-auto', levers.dismissWrapper, classes.dismissWrapper)
+  }, dismissBtn), (props.hasIcon && !props.isIconTop || props.hasLabel && !props.isLabelTop) && /*#__PURE__*/React.createElement("div", {
+    className: clsxd('su-order-1 su-rs-mr-1 su-mb-15 md:su-mb-0 su-flex su-flex-shrink su-items-center su-w-full md:su-w-max', levers.headerWrapper, classes.headerWrapper)
   }, props.hasIcon && !props.isIconTop && /*#__PURE__*/React.createElement("span", {
     className: clsxd('su-mr-5 su-inline-block', levers.headerIcon, classes.headerIcon)
   }, icon), props.hasLabel && !props.isLabelTop && /*#__PURE__*/React.createElement("span", {
     className: clsxd('su-inline-block su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)
-  }, (_props$label = props.label) != null ? _props$label : 'Information')), /*#__PURE__*/React.createElement("div", {
+  }, (_props$label = props.label) != null ? _props$label : 'Alert:')), /*#__PURE__*/React.createElement("div", {
     className: clsxd('su-order-2 su-flex-1 su-flex-grow', levers.bodyWrapper, classes.bodyWrapper)
+  }, (props.hasIcon && props.isIconTop || props.hasLabel && props.isLabelTop) && /*#__PURE__*/React.createElement("div", {
+    className: "su-flex su-items-center su-rs-mb-0"
   }, props.hasIcon && props.isIconTop && /*#__PURE__*/React.createElement("span", {
-    className: clsxd('su-mr-5 su-text-left su-ml-0', levers.headerIcon, classes.headerIcon)
-  }, icon), props.hasLabel && props.isLabelTop && /*#__PURE__*/React.createElement("span", {
-    className: clsxd('su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)
-  }, (_props$label2 = props.label) != null ? _props$label2 : 'Information'), props.heading && /*#__PURE__*/React.createElement("h3", {
-    className: clsxd('su-type-2 su-mb-03em', levers.bodyHeading, classes.bodyHeading)
+    className: clsxd('su-inline-block su-mr-5 su-text-left su-ml-0', levers.headerIcon, classes.headerIcon)
+  }, icon), props.hasLabel && props.isLabelTop && /*#__PURE__*/React.createElement("div", {
+    className: clsxd('su-inline-block su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)
+  }, (_props$label2 = props.label) != null ? _props$label2 : 'Alert:')), props.heading && /*#__PURE__*/React.createElement("h3", {
+    className: clsxd('su-type-1 su-rs-mb-neg1', levers.bodyHeading, classes.bodyHeading)
   }, props.heading), /*#__PURE__*/React.createElement("div", {
     className: clsxd('su-text-normal', levers.body, classes.body)
   }, children), props.footer && /*#__PURE__*/React.createElement("div", {
@@ -1805,21 +1893,6 @@ Logo.defaultProps = {
   color: 'cardinal-red',
   type: 'short',
   isLink: true
-};
-
-var SrOnlyText = function SrOnlyText(props) {
-  var _props$srText;
-
-  var txt = (_props$srText = props.srText) != null ? _props$srText : '(link is external)';
-  return /*#__PURE__*/React.createElement("span", {
-    className: "su-sr-only"
-  }, txt);
-};
-SrOnlyText.propTypes = {
-  srText: propTypes.string
-};
-SrOnlyText.defaultProps = {
-  srText: '(link is external)'
 };
 
 var GlobalFooter = function GlobalFooter(_ref) {
@@ -2375,4 +2448,4 @@ var StyledLink = function StyledLink(props) {
   }, props.attributes), props.children, classes.icon && classes.icon);
 };
 
-export { Alert, Button, Container, FlexBox, FlexCell, GlobalFooter, Grid, GridCell, Heading, IdentityBar, LocalFooter, Lockup, Logo, Skiplink, SrOnlyText, StyledLink };
+export { Alert, Button, Container, DismissButton, FlexBox, FlexCell, GlobalFooter, Grid, GridCell, Heading, IdentityBar, LocalFooter, Lockup, Logo, Skiplink, SrOnlyText, StyledLink };

--- a/dist/decanter-react.modern.js
+++ b/dist/decanter-react.modern.js
@@ -1237,10 +1237,10 @@ var DismissButton = function DismissButton(_ref) {
       props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconSize", "iconProps", "customIcon", "onClick"]);
 
   var levers = {};
-  iconProps = Object.assign({
+  iconProps = _extends({
     height: iconSize != null ? iconSize : 20,
     width: iconSize != null ? iconSize : 20
-  }, _extends({}, iconProps));
+  }, iconProps);
 
   if (color && dismissIconColors.includes(color)) {
     switch (color) {

--- a/dist/decanter-react.modern.js
+++ b/dist/decanter-react.modern.js
@@ -1224,22 +1224,22 @@ SrOnlyText.defaultProps = {
 };
 
 var DismissButton = function DismissButton(_ref) {
-  var _ref$classes = _ref.classes,
-      classes = _ref$classes === void 0 ? {} : _ref$classes,
+  var className = _ref.className,
       text = _ref.text,
       srText = _ref.srText,
       color = _ref.color,
       icon = _ref.icon,
       iconType = _ref.iconType,
+      iconProps = _ref.iconProps,
       customIcon = _ref.customIcon,
       onClick = _ref.onClick,
-      props = _objectWithoutPropertiesLoose(_ref, ["classes", "text", "srText", "color", "icon", "iconType", "customIcon", "onClick"]);
+      props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconProps", "customIcon", "onClick"]);
 
   var levers = {};
-  var iconProps = {
+  iconProps = Object.assign({
     height: 20,
     width: 20
-  };
+  }, _extends({}, iconProps));
 
   if (color && dismissIconColors.includes(color)) {
     switch (color) {
@@ -1268,14 +1268,13 @@ var DismissButton = function DismissButton(_ref) {
   var defaultIcon = /*#__PURE__*/React.createElement(Icon, _extends({
     icon: heroicon,
     type: heroiconType,
-    "aria-hidden": "true",
-    className: classes.icon
+    "aria-hidden": "true"
   }, iconProps));
   var dismissIcon = customIcon != null ? customIcon : defaultIcon;
   return /*#__PURE__*/React.createElement(Button, _extends({
     variant: "none",
     size: "minimal",
-    className: clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display', levers.color, classes.wrapper),
+    className: clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display', levers.color, className),
     onClick: onClick
   }, props), text, srText && /*#__PURE__*/React.createElement(SrOnlyText, {
     srText: ' ' + srText
@@ -1289,10 +1288,8 @@ DismissButton.propTypes = {
   iconType: propTypes.oneOf(dismissIconTypes),
   customIcon: propTypes.element,
   onClick: propTypes.func,
-  classes: propTypes.shape({
-    wrapper: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array]),
-    icon: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array])
-  })
+  iconProps: propTypes.object,
+  className: propTypes.oneOfType([propTypes.string, propTypes.array, propTypes.object])
 };
 DismissButton.defaultProps = {
   color: 'black',
@@ -1344,7 +1341,7 @@ var Alert = function Alert(_ref) {
           icon: "check-circle",
           type: "solid",
           "aria-hidden": "true",
-          className: clsxd(classes.icon)
+          className: classes.icon
         }, iconProps));
         break;
 
@@ -1356,7 +1353,7 @@ var Alert = function Alert(_ref) {
           icon: "exclamation-circle",
           type: "solid",
           "aria-hidden": "true",
-          className: clsxd(classes.icon)
+          className: classes.icon
         }, iconProps));
         break;
 
@@ -1368,7 +1365,7 @@ var Alert = function Alert(_ref) {
           icon: "information-circle",
           type: "solid",
           "aria-hidden": "true",
-          className: clsxd(classes.icon)
+          className: classes.icon
         }, iconProps));
         break;
 
@@ -1380,7 +1377,7 @@ var Alert = function Alert(_ref) {
           icon: "ban",
           type: "solid",
           "aria-hidden": "true",
-          className: clsxd(classes.icon)
+          className: classes.icon
         }, iconProps));
         break;
     }
@@ -1393,9 +1390,9 @@ var Alert = function Alert(_ref) {
       setDismissed(true);
     },
     color: levers.dismiss,
-    classes: {
-      icon: 'su-ml-02em',
-      wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest su-mr-0 su-ml-auto'
+    className: "su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest su-mr-0 su-ml-auto",
+    iconProps: {
+      className: 'su-ml-02em'
     }
   });
   var dismissBtn = (_props$dismissBtn = props.dismissBtn) != null ? _props$dismissBtn : DefaultDismiss;

--- a/dist/decanter-react.modern.js
+++ b/dist/decanter-react.modern.js
@@ -1230,15 +1230,16 @@ var DismissButton = function DismissButton(_ref) {
       color = _ref.color,
       icon = _ref.icon,
       iconType = _ref.iconType,
+      iconSize = _ref.iconSize,
       iconProps = _ref.iconProps,
       customIcon = _ref.customIcon,
       onClick = _ref.onClick,
-      props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconProps", "customIcon", "onClick"]);
+      props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconSize", "iconProps", "customIcon", "onClick"]);
 
   var levers = {};
   iconProps = Object.assign({
-    height: 20,
-    width: 20
+    height: iconSize != null ? iconSize : 20,
+    width: iconSize != null ? iconSize : 20
   }, _extends({}, iconProps));
 
   if (color && dismissIconColors.includes(color)) {
@@ -1289,6 +1290,7 @@ DismissButton.propTypes = {
   customIcon: propTypes.element,
   onClick: propTypes.func,
   iconProps: propTypes.object,
+  iconSize: propTypes.number,
   className: propTypes.oneOfType([propTypes.string, propTypes.array, propTypes.object])
 };
 DismissButton.defaultProps = {

--- a/dist/decanter-react.module.js
+++ b/dist/decanter-react.module.js
@@ -1116,6 +1116,10 @@ var alertTypes = ['info', 'warning', 'error', 'success'];
 var lightText = 'su-text-white hover:su-link-no-underline';
 var darkText = 'su-text-black su-link-black-true hover:su-link-no-underline';
 
+var dismissIconColors = ['black', 'white', 'unset'];
+var dismissIconOptions = ['x-circle', 'x', 'none'];
+var dismissIconTypes = ['solid', 'outline'];
+
 var buttonVariants = ['primary', 'secondary', 'none'];
 var buttonSizes = ['big', 'small', 'minimal'];
 var buttonTypes = ['button', 'submit', 'reset'];
@@ -1204,6 +1208,98 @@ Button.defaultProps = {
   ref: null
 };
 
+var SrOnlyText = function SrOnlyText(props) {
+  var _props$srText;
+
+  var txt = (_props$srText = props.srText) != null ? _props$srText : '(link is external)';
+  return /*#__PURE__*/React.createElement("span", {
+    className: "su-sr-only"
+  }, txt);
+};
+SrOnlyText.propTypes = {
+  srText: propTypes.string
+};
+SrOnlyText.defaultProps = {
+  srText: '(link is external)'
+};
+
+var DismissButton = function DismissButton(_ref) {
+  var _ref$classes = _ref.classes,
+      classes = _ref$classes === void 0 ? {} : _ref$classes,
+      text = _ref.text,
+      srText = _ref.srText,
+      color = _ref.color,
+      icon = _ref.icon,
+      iconType = _ref.iconType,
+      customIcon = _ref.customIcon,
+      onClick = _ref.onClick,
+      props = _objectWithoutPropertiesLoose(_ref, ["classes", "text", "srText", "color", "icon", "iconType", "customIcon", "onClick"]);
+
+  var levers = {};
+  var iconProps = {
+    height: 20,
+    width: 20
+  };
+
+  if (color && dismissIconColors.includes(color)) {
+    switch (color) {
+      case 'black':
+        levers.color = 'su-text-black hocus:su-text-black';
+        break;
+
+      case 'white':
+        levers.color = 'su-text-white hocus:su-text-white';
+        break;
+    }
+  }
+
+  var heroicon = '';
+
+  if (icon && dismissIconOptions.includes(icon)) {
+    heroicon = icon;
+  }
+
+  var heroiconType = 'solid';
+
+  if (iconType && dismissIconTypes.includes(iconType)) {
+    heroiconType = iconType;
+  }
+
+  var defaultIcon = /*#__PURE__*/React.createElement(Icon, _extends({
+    icon: heroicon,
+    type: heroiconType,
+    "aria-hidden": "true",
+    className: classes.icon
+  }, iconProps));
+  var dismissIcon = customIcon != null ? customIcon : defaultIcon;
+  return /*#__PURE__*/React.createElement(Button, _extends({
+    variant: "none",
+    size: "minimal",
+    className: clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display', levers.color, classes.wrapper),
+    onClick: onClick
+  }, props), text, srText && /*#__PURE__*/React.createElement(SrOnlyText, {
+    srText: ' ' + srText
+  }), dismissIcon);
+};
+DismissButton.propTypes = {
+  text: propTypes.string,
+  srText: propTypes.string,
+  color: propTypes.oneOf(dismissIconColors),
+  icon: propTypes.oneOf(dismissIconOptions),
+  iconType: propTypes.oneOf(dismissIconTypes),
+  customIcon: propTypes.element,
+  onClick: propTypes.func,
+  classes: propTypes.shape({
+    wrapper: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array]),
+    icon: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array])
+  })
+};
+DismissButton.defaultProps = {
+  color: 'black',
+  icon: 'x-circle',
+  iconType: 'solid'
+};
+
 var Alert = function Alert(_ref) {
   var _props$icon, _props$dismissBtn, _props$label, _props$label2;
 
@@ -1215,8 +1311,8 @@ var Alert = function Alert(_ref) {
 
   var levers = {};
   var iconProps = {
-    height: 24,
-    width: 24
+    height: 20,
+    width: 20
   };
 
   var _useState = useState(false),
@@ -1224,7 +1320,7 @@ var Alert = function Alert(_ref) {
       setDismissed = _useState[1];
 
   levers.wrapper = 'su-bg-foggy-light';
-  levers.dismiss = clsxd(darkText, 'hover:su-text-black focus:su-text-black');
+  levers.dismiss = 'black';
 
   if (props.isLargeIcon) {
     iconProps.height = 60;
@@ -1234,31 +1330,20 @@ var Alert = function Alert(_ref) {
   var defaultIcon = /*#__PURE__*/React.createElement(Icon, _extends({
     icon: "bell",
     type: "outline",
-    className: clsxd({
-      'su-inline-block': props.isIconTop
-    }, classes.icon)
+    "aria-hidden": "true",
+    className: classes.icon
   }, iconProps));
-
-  if (props.isLabelTop) {
-    levers.label = clsxd('su-rs-mb-neg1', {
-      'su-inline-block': !props.isIconTop
-    });
-    classes.icon = clsxd(classes.icon, 'su-inline-block');
-  }
-
-  if (props.isIconTop && !props.isLabelTop) {
-    levers.headerIcon = clsxd(levers.headerIcon, 'su-block su-rs-mb-neg1');
-  }
 
   if (props.type && alertTypes.includes(props.type)) {
     switch (props.type) {
       case 'success':
         levers.wrapper = 'su-bg-digital-green su-text-white su-link-white';
         levers.body = lightText;
-        levers.dismiss = lightText;
+        levers.dismiss = 'white';
         defaultIcon = /*#__PURE__*/React.createElement(Icon, _extends({
           icon: "check-circle",
           type: "solid",
+          "aria-hidden": "true",
           className: clsxd(classes.icon)
         }, iconProps));
         break;
@@ -1266,10 +1351,11 @@ var Alert = function Alert(_ref) {
       case 'warning':
         levers.wrapper = 'su-bg-illuminating-dark';
         levers.body = darkText;
-        levers.dismiss = clsxd(darkText, 'hover:su-text-black');
+        levers.dismiss = 'black';
         defaultIcon = /*#__PURE__*/React.createElement(Icon, _extends({
           icon: "exclamation-circle",
           type: "solid",
+          "aria-hidden": "true",
           className: clsxd(classes.icon)
         }, iconProps));
         break;
@@ -1277,10 +1363,11 @@ var Alert = function Alert(_ref) {
       case 'info':
         levers.wrapper = 'su-bg-digital-blue su-text-white su-link-white';
         levers.body = lightText;
-        levers.dismiss = lightText;
+        levers.dismiss = 'white';
         defaultIcon = /*#__PURE__*/React.createElement(Icon, _extends({
           icon: "information-circle",
           type: "solid",
+          "aria-hidden": "true",
           className: clsxd(classes.icon)
         }, iconProps));
         break;
@@ -1288,10 +1375,11 @@ var Alert = function Alert(_ref) {
       case 'error':
         levers.wrapper = 'su-bg-digital-red su-text-white su-link-white';
         levers.body = lightText;
-        levers.dismiss = lightText;
+        levers.dismiss = 'white';
         defaultIcon = /*#__PURE__*/React.createElement(Icon, _extends({
           icon: "ban",
           type: "solid",
+          "aria-hidden": "true",
           className: clsxd(classes.icon)
         }, iconProps));
         break;
@@ -1299,19 +1387,17 @@ var Alert = function Alert(_ref) {
   }
 
   var icon = (_props$icon = props.icon) != null ? _props$icon : defaultIcon;
-  var DefaultDismiss = /*#__PURE__*/React.createElement(Button, {
-    className: clsxd('su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest', levers.dismiss, classes.dismiss),
-    "aria-label": "Dismiss Alert",
+  var DefaultDismiss = /*#__PURE__*/React.createElement(DismissButton, {
+    text: "Dismiss",
     onClick: function onClick() {
       setDismissed(true);
     },
-    variant: "none",
-    size: "minimal"
-  }, "Dismiss ", /*#__PURE__*/React.createElement(Icon, {
-    icon: "x-circle",
-    type: "solid",
-    className: 'su-inline-block su-h-25 su-w-25'
-  }));
+    color: levers.dismiss,
+    classes: {
+      icon: 'su-ml-02em',
+      wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest su-mr-0 su-ml-auto'
+    }
+  });
   var dismissBtn = (_props$dismissBtn = props.dismissBtn) != null ? _props$dismissBtn : DefaultDismiss;
 
   if (isDismissed === true) {
@@ -1324,21 +1410,23 @@ var Alert = function Alert(_ref) {
   }, /*#__PURE__*/React.createElement("div", {
     className: clsxd('su-cc su-flex su-flex-wrap su-rs-py-1 sm:su-items-center', levers.container, classes.container)
   }, props.hasDismiss && /*#__PURE__*/React.createElement("div", {
-    className: clsxd('su-order-3 su-rs-ml-1 su-items-end su-flex-shrink su-text-right su-w-full sm:su-w-auto', levers.dismissWrapper, classes.dismissWrapper)
-  }, dismissBtn), /*#__PURE__*/React.createElement("div", {
-    className: clsxd('su-order-1 su-rs-mr-1 su-flex su-flex-shrink su-items-center su-mb-4 su-w-full su-pb-10 md:su-w-max', levers.headerWrapper, classes.headerWrapper)
+    className: clsxd('su-order-3 su-rs-ml-1 su-mt-15 sm:su-mt-0 su-items-center su-flex-shrink su-text-right su-w-full sm:su-w-auto', levers.dismissWrapper, classes.dismissWrapper)
+  }, dismissBtn), (props.hasIcon && !props.isIconTop || props.hasLabel && !props.isLabelTop) && /*#__PURE__*/React.createElement("div", {
+    className: clsxd('su-order-1 su-rs-mr-1 su-mb-15 md:su-mb-0 su-flex su-flex-shrink su-items-center su-w-full md:su-w-max', levers.headerWrapper, classes.headerWrapper)
   }, props.hasIcon && !props.isIconTop && /*#__PURE__*/React.createElement("span", {
     className: clsxd('su-mr-5 su-inline-block', levers.headerIcon, classes.headerIcon)
   }, icon), props.hasLabel && !props.isLabelTop && /*#__PURE__*/React.createElement("span", {
     className: clsxd('su-inline-block su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)
-  }, (_props$label = props.label) != null ? _props$label : 'Information')), /*#__PURE__*/React.createElement("div", {
+  }, (_props$label = props.label) != null ? _props$label : 'Alert:')), /*#__PURE__*/React.createElement("div", {
     className: clsxd('su-order-2 su-flex-1 su-flex-grow', levers.bodyWrapper, classes.bodyWrapper)
+  }, (props.hasIcon && props.isIconTop || props.hasLabel && props.isLabelTop) && /*#__PURE__*/React.createElement("div", {
+    className: "su-flex su-items-center su-rs-mb-0"
   }, props.hasIcon && props.isIconTop && /*#__PURE__*/React.createElement("span", {
-    className: clsxd('su-mr-5 su-text-left su-ml-0', levers.headerIcon, classes.headerIcon)
-  }, icon), props.hasLabel && props.isLabelTop && /*#__PURE__*/React.createElement("span", {
-    className: clsxd('su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)
-  }, (_props$label2 = props.label) != null ? _props$label2 : 'Information'), props.heading && /*#__PURE__*/React.createElement("h3", {
-    className: clsxd('su-type-2 su-mb-03em', levers.bodyHeading, classes.bodyHeading)
+    className: clsxd('su-inline-block su-mr-5 su-text-left su-ml-0', levers.headerIcon, classes.headerIcon)
+  }, icon), props.hasLabel && props.isLabelTop && /*#__PURE__*/React.createElement("div", {
+    className: clsxd('su-inline-block su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)
+  }, (_props$label2 = props.label) != null ? _props$label2 : 'Alert:')), props.heading && /*#__PURE__*/React.createElement("h3", {
+    className: clsxd('su-type-1 su-rs-mb-neg1', levers.bodyHeading, classes.bodyHeading)
   }, props.heading), /*#__PURE__*/React.createElement("div", {
     className: clsxd('su-text-normal', levers.body, classes.body)
   }, children), props.footer && /*#__PURE__*/React.createElement("div", {
@@ -1805,21 +1893,6 @@ Logo.defaultProps = {
   color: 'cardinal-red',
   type: 'short',
   isLink: true
-};
-
-var SrOnlyText = function SrOnlyText(props) {
-  var _props$srText;
-
-  var txt = (_props$srText = props.srText) != null ? _props$srText : '(link is external)';
-  return /*#__PURE__*/React.createElement("span", {
-    className: "su-sr-only"
-  }, txt);
-};
-SrOnlyText.propTypes = {
-  srText: propTypes.string
-};
-SrOnlyText.defaultProps = {
-  srText: '(link is external)'
 };
 
 var GlobalFooter = function GlobalFooter(_ref) {
@@ -2375,4 +2448,4 @@ var StyledLink = function StyledLink(props) {
   }, props.attributes), props.children, classes.icon && classes.icon);
 };
 
-export { Alert, Button, Container, FlexBox, FlexCell, GlobalFooter, Grid, GridCell, Heading, IdentityBar, LocalFooter, Lockup, Logo, Skiplink, SrOnlyText, StyledLink };
+export { Alert, Button, Container, DismissButton, FlexBox, FlexCell, GlobalFooter, Grid, GridCell, Heading, IdentityBar, LocalFooter, Lockup, Logo, Skiplink, SrOnlyText, StyledLink };

--- a/dist/decanter-react.module.js
+++ b/dist/decanter-react.module.js
@@ -1237,10 +1237,10 @@ var DismissButton = function DismissButton(_ref) {
       props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconSize", "iconProps", "customIcon", "onClick"]);
 
   var levers = {};
-  iconProps = Object.assign({
+  iconProps = _extends({
     height: iconSize != null ? iconSize : 20,
     width: iconSize != null ? iconSize : 20
-  }, _extends({}, iconProps));
+  }, iconProps);
 
   if (color && dismissIconColors.includes(color)) {
     switch (color) {

--- a/dist/decanter-react.module.js
+++ b/dist/decanter-react.module.js
@@ -1224,22 +1224,22 @@ SrOnlyText.defaultProps = {
 };
 
 var DismissButton = function DismissButton(_ref) {
-  var _ref$classes = _ref.classes,
-      classes = _ref$classes === void 0 ? {} : _ref$classes,
+  var className = _ref.className,
       text = _ref.text,
       srText = _ref.srText,
       color = _ref.color,
       icon = _ref.icon,
       iconType = _ref.iconType,
+      iconProps = _ref.iconProps,
       customIcon = _ref.customIcon,
       onClick = _ref.onClick,
-      props = _objectWithoutPropertiesLoose(_ref, ["classes", "text", "srText", "color", "icon", "iconType", "customIcon", "onClick"]);
+      props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconProps", "customIcon", "onClick"]);
 
   var levers = {};
-  var iconProps = {
+  iconProps = Object.assign({
     height: 20,
     width: 20
-  };
+  }, _extends({}, iconProps));
 
   if (color && dismissIconColors.includes(color)) {
     switch (color) {
@@ -1268,14 +1268,13 @@ var DismissButton = function DismissButton(_ref) {
   var defaultIcon = /*#__PURE__*/React.createElement(Icon, _extends({
     icon: heroicon,
     type: heroiconType,
-    "aria-hidden": "true",
-    className: classes.icon
+    "aria-hidden": "true"
   }, iconProps));
   var dismissIcon = customIcon != null ? customIcon : defaultIcon;
   return /*#__PURE__*/React.createElement(Button, _extends({
     variant: "none",
     size: "minimal",
-    className: clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display', levers.color, classes.wrapper),
+    className: clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display', levers.color, className),
     onClick: onClick
   }, props), text, srText && /*#__PURE__*/React.createElement(SrOnlyText, {
     srText: ' ' + srText
@@ -1289,10 +1288,8 @@ DismissButton.propTypes = {
   iconType: propTypes.oneOf(dismissIconTypes),
   customIcon: propTypes.element,
   onClick: propTypes.func,
-  classes: propTypes.shape({
-    wrapper: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array]),
-    icon: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array])
-  })
+  iconProps: propTypes.object,
+  className: propTypes.oneOfType([propTypes.string, propTypes.array, propTypes.object])
 };
 DismissButton.defaultProps = {
   color: 'black',
@@ -1344,7 +1341,7 @@ var Alert = function Alert(_ref) {
           icon: "check-circle",
           type: "solid",
           "aria-hidden": "true",
-          className: clsxd(classes.icon)
+          className: classes.icon
         }, iconProps));
         break;
 
@@ -1356,7 +1353,7 @@ var Alert = function Alert(_ref) {
           icon: "exclamation-circle",
           type: "solid",
           "aria-hidden": "true",
-          className: clsxd(classes.icon)
+          className: classes.icon
         }, iconProps));
         break;
 
@@ -1368,7 +1365,7 @@ var Alert = function Alert(_ref) {
           icon: "information-circle",
           type: "solid",
           "aria-hidden": "true",
-          className: clsxd(classes.icon)
+          className: classes.icon
         }, iconProps));
         break;
 
@@ -1380,7 +1377,7 @@ var Alert = function Alert(_ref) {
           icon: "ban",
           type: "solid",
           "aria-hidden": "true",
-          className: clsxd(classes.icon)
+          className: classes.icon
         }, iconProps));
         break;
     }
@@ -1393,9 +1390,9 @@ var Alert = function Alert(_ref) {
       setDismissed(true);
     },
     color: levers.dismiss,
-    classes: {
-      icon: 'su-ml-02em',
-      wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest su-mr-0 su-ml-auto'
+    className: "su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest su-mr-0 su-ml-auto",
+    iconProps: {
+      className: 'su-ml-02em'
     }
   });
   var dismissBtn = (_props$dismissBtn = props.dismissBtn) != null ? _props$dismissBtn : DefaultDismiss;

--- a/dist/decanter-react.module.js
+++ b/dist/decanter-react.module.js
@@ -1230,15 +1230,16 @@ var DismissButton = function DismissButton(_ref) {
       color = _ref.color,
       icon = _ref.icon,
       iconType = _ref.iconType,
+      iconSize = _ref.iconSize,
       iconProps = _ref.iconProps,
       customIcon = _ref.customIcon,
       onClick = _ref.onClick,
-      props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconProps", "customIcon", "onClick"]);
+      props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconSize", "iconProps", "customIcon", "onClick"]);
 
   var levers = {};
   iconProps = Object.assign({
-    height: 20,
-    width: 20
+    height: iconSize != null ? iconSize : 20,
+    width: iconSize != null ? iconSize : 20
   }, _extends({}, iconProps));
 
   if (color && dismissIconColors.includes(color)) {
@@ -1289,6 +1290,7 @@ DismissButton.propTypes = {
   customIcon: propTypes.element,
   onClick: propTypes.func,
   iconProps: propTypes.object,
+  iconSize: propTypes.number,
   className: propTypes.oneOfType([propTypes.string, propTypes.array, propTypes.object])
 };
 DismissButton.defaultProps = {

--- a/dist/decanter-react.umd.js
+++ b/dist/decanter-react.umd.js
@@ -1242,10 +1242,10 @@
         props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconSize", "iconProps", "customIcon", "onClick"]);
 
     var levers = {};
-    iconProps = Object.assign({
+    iconProps = _extends({
       height: iconSize != null ? iconSize : 20,
       width: iconSize != null ? iconSize : 20
-    }, _extends({}, iconProps));
+    }, iconProps);
 
     if (color && dismissIconColors.includes(color)) {
       switch (color) {

--- a/dist/decanter-react.umd.js
+++ b/dist/decanter-react.umd.js
@@ -1235,15 +1235,16 @@
         color = _ref.color,
         icon = _ref.icon,
         iconType = _ref.iconType,
+        iconSize = _ref.iconSize,
         iconProps = _ref.iconProps,
         customIcon = _ref.customIcon,
         onClick = _ref.onClick,
-        props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconProps", "customIcon", "onClick"]);
+        props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconSize", "iconProps", "customIcon", "onClick"]);
 
     var levers = {};
     iconProps = Object.assign({
-      height: 20,
-      width: 20
+      height: iconSize != null ? iconSize : 20,
+      width: iconSize != null ? iconSize : 20
     }, _extends({}, iconProps));
 
     if (color && dismissIconColors.includes(color)) {
@@ -1294,6 +1295,7 @@
     customIcon: propTypes.element,
     onClick: propTypes.func,
     iconProps: propTypes.object,
+    iconSize: propTypes.number,
     className: propTypes.oneOfType([propTypes.string, propTypes.array, propTypes.object])
   };
   DismissButton.defaultProps = {

--- a/dist/decanter-react.umd.js
+++ b/dist/decanter-react.umd.js
@@ -1229,22 +1229,22 @@
   };
 
   var DismissButton = function DismissButton(_ref) {
-    var _ref$classes = _ref.classes,
-        classes = _ref$classes === void 0 ? {} : _ref$classes,
+    var className = _ref.className,
         text = _ref.text,
         srText = _ref.srText,
         color = _ref.color,
         icon = _ref.icon,
         iconType = _ref.iconType,
+        iconProps = _ref.iconProps,
         customIcon = _ref.customIcon,
         onClick = _ref.onClick,
-        props = _objectWithoutPropertiesLoose(_ref, ["classes", "text", "srText", "color", "icon", "iconType", "customIcon", "onClick"]);
+        props = _objectWithoutPropertiesLoose(_ref, ["className", "text", "srText", "color", "icon", "iconType", "iconProps", "customIcon", "onClick"]);
 
     var levers = {};
-    var iconProps = {
+    iconProps = Object.assign({
       height: 20,
       width: 20
-    };
+    }, _extends({}, iconProps));
 
     if (color && dismissIconColors.includes(color)) {
       switch (color) {
@@ -1273,14 +1273,13 @@
     var defaultIcon = /*#__PURE__*/React__default.createElement(Icon, _extends({
       icon: heroicon,
       type: heroiconType,
-      "aria-hidden": "true",
-      className: classes.icon
+      "aria-hidden": "true"
     }, iconProps));
     var dismissIcon = customIcon != null ? customIcon : defaultIcon;
     return /*#__PURE__*/React__default.createElement(Button, _extends({
       variant: "none",
       size: "minimal",
-      className: clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display', levers.color, classes.wrapper),
+      className: clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display', levers.color, className),
       onClick: onClick
     }, props), text, srText && /*#__PURE__*/React__default.createElement(SrOnlyText, {
       srText: ' ' + srText
@@ -1294,10 +1293,8 @@
     iconType: propTypes.oneOf(dismissIconTypes),
     customIcon: propTypes.element,
     onClick: propTypes.func,
-    classes: propTypes.shape({
-      wrapper: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array]),
-      icon: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array])
-    })
+    iconProps: propTypes.object,
+    className: propTypes.oneOfType([propTypes.string, propTypes.array, propTypes.object])
   };
   DismissButton.defaultProps = {
     color: 'black',
@@ -1349,7 +1346,7 @@
             icon: "check-circle",
             type: "solid",
             "aria-hidden": "true",
-            className: clsxd(classes.icon)
+            className: classes.icon
           }, iconProps));
           break;
 
@@ -1361,7 +1358,7 @@
             icon: "exclamation-circle",
             type: "solid",
             "aria-hidden": "true",
-            className: clsxd(classes.icon)
+            className: classes.icon
           }, iconProps));
           break;
 
@@ -1373,7 +1370,7 @@
             icon: "information-circle",
             type: "solid",
             "aria-hidden": "true",
-            className: clsxd(classes.icon)
+            className: classes.icon
           }, iconProps));
           break;
 
@@ -1385,7 +1382,7 @@
             icon: "ban",
             type: "solid",
             "aria-hidden": "true",
-            className: clsxd(classes.icon)
+            className: classes.icon
           }, iconProps));
           break;
       }
@@ -1398,9 +1395,9 @@
         setDismissed(true);
       },
       color: levers.dismiss,
-      classes: {
-        icon: 'su-ml-02em',
-        wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest su-mr-0 su-ml-auto'
+      className: "su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest su-mr-0 su-ml-auto",
+      iconProps: {
+        className: 'su-ml-02em'
       }
     });
     var dismissBtn = (_props$dismissBtn = props.dismissBtn) != null ? _props$dismissBtn : DefaultDismiss;

--- a/dist/decanter-react.umd.js
+++ b/dist/decanter-react.umd.js
@@ -1121,6 +1121,10 @@
   var lightText = 'su-text-white hover:su-link-no-underline';
   var darkText = 'su-text-black su-link-black-true hover:su-link-no-underline';
 
+  var dismissIconColors = ['black', 'white', 'unset'];
+  var dismissIconOptions = ['x-circle', 'x', 'none'];
+  var dismissIconTypes = ['solid', 'outline'];
+
   var buttonVariants = ['primary', 'secondary', 'none'];
   var buttonSizes = ['big', 'small', 'minimal'];
   var buttonTypes = ['button', 'submit', 'reset'];
@@ -1209,6 +1213,98 @@
     ref: null
   };
 
+  var SrOnlyText = function SrOnlyText(props) {
+    var _props$srText;
+
+    var txt = (_props$srText = props.srText) != null ? _props$srText : '(link is external)';
+    return /*#__PURE__*/React__default.createElement("span", {
+      className: "su-sr-only"
+    }, txt);
+  };
+  SrOnlyText.propTypes = {
+    srText: propTypes.string
+  };
+  SrOnlyText.defaultProps = {
+    srText: '(link is external)'
+  };
+
+  var DismissButton = function DismissButton(_ref) {
+    var _ref$classes = _ref.classes,
+        classes = _ref$classes === void 0 ? {} : _ref$classes,
+        text = _ref.text,
+        srText = _ref.srText,
+        color = _ref.color,
+        icon = _ref.icon,
+        iconType = _ref.iconType,
+        customIcon = _ref.customIcon,
+        onClick = _ref.onClick,
+        props = _objectWithoutPropertiesLoose(_ref, ["classes", "text", "srText", "color", "icon", "iconType", "customIcon", "onClick"]);
+
+    var levers = {};
+    var iconProps = {
+      height: 20,
+      width: 20
+    };
+
+    if (color && dismissIconColors.includes(color)) {
+      switch (color) {
+        case 'black':
+          levers.color = 'su-text-black hocus:su-text-black';
+          break;
+
+        case 'white':
+          levers.color = 'su-text-white hocus:su-text-white';
+          break;
+      }
+    }
+
+    var heroicon = '';
+
+    if (icon && dismissIconOptions.includes(icon)) {
+      heroicon = icon;
+    }
+
+    var heroiconType = 'solid';
+
+    if (iconType && dismissIconTypes.includes(iconType)) {
+      heroiconType = iconType;
+    }
+
+    var defaultIcon = /*#__PURE__*/React__default.createElement(Icon, _extends({
+      icon: heroicon,
+      type: heroiconType,
+      "aria-hidden": "true",
+      className: classes.icon
+    }, iconProps));
+    var dismissIcon = customIcon != null ? customIcon : defaultIcon;
+    return /*#__PURE__*/React__default.createElement(Button, _extends({
+      variant: "none",
+      size: "minimal",
+      className: clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display', levers.color, classes.wrapper),
+      onClick: onClick
+    }, props), text, srText && /*#__PURE__*/React__default.createElement(SrOnlyText, {
+      srText: ' ' + srText
+    }), dismissIcon);
+  };
+  DismissButton.propTypes = {
+    text: propTypes.string,
+    srText: propTypes.string,
+    color: propTypes.oneOf(dismissIconColors),
+    icon: propTypes.oneOf(dismissIconOptions),
+    iconType: propTypes.oneOf(dismissIconTypes),
+    customIcon: propTypes.element,
+    onClick: propTypes.func,
+    classes: propTypes.shape({
+      wrapper: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array]),
+      icon: propTypes.oneOfType([propTypes.string, propTypes.object, propTypes.array])
+    })
+  };
+  DismissButton.defaultProps = {
+    color: 'black',
+    icon: 'x-circle',
+    iconType: 'solid'
+  };
+
   var Alert = function Alert(_ref) {
     var _props$icon, _props$dismissBtn, _props$label, _props$label2;
 
@@ -1220,8 +1316,8 @@
 
     var levers = {};
     var iconProps = {
-      height: 24,
-      width: 24
+      height: 20,
+      width: 20
     };
 
     var _useState = React.useState(false),
@@ -1229,7 +1325,7 @@
         setDismissed = _useState[1];
 
     levers.wrapper = 'su-bg-foggy-light';
-    levers.dismiss = clsxd(darkText, 'hover:su-text-black focus:su-text-black');
+    levers.dismiss = 'black';
 
     if (props.isLargeIcon) {
       iconProps.height = 60;
@@ -1239,31 +1335,20 @@
     var defaultIcon = /*#__PURE__*/React__default.createElement(Icon, _extends({
       icon: "bell",
       type: "outline",
-      className: clsxd({
-        'su-inline-block': props.isIconTop
-      }, classes.icon)
+      "aria-hidden": "true",
+      className: classes.icon
     }, iconProps));
-
-    if (props.isLabelTop) {
-      levers.label = clsxd('su-rs-mb-neg1', {
-        'su-inline-block': !props.isIconTop
-      });
-      classes.icon = clsxd(classes.icon, 'su-inline-block');
-    }
-
-    if (props.isIconTop && !props.isLabelTop) {
-      levers.headerIcon = clsxd(levers.headerIcon, 'su-block su-rs-mb-neg1');
-    }
 
     if (props.type && alertTypes.includes(props.type)) {
       switch (props.type) {
         case 'success':
           levers.wrapper = 'su-bg-digital-green su-text-white su-link-white';
           levers.body = lightText;
-          levers.dismiss = lightText;
+          levers.dismiss = 'white';
           defaultIcon = /*#__PURE__*/React__default.createElement(Icon, _extends({
             icon: "check-circle",
             type: "solid",
+            "aria-hidden": "true",
             className: clsxd(classes.icon)
           }, iconProps));
           break;
@@ -1271,10 +1356,11 @@
         case 'warning':
           levers.wrapper = 'su-bg-illuminating-dark';
           levers.body = darkText;
-          levers.dismiss = clsxd(darkText, 'hover:su-text-black');
+          levers.dismiss = 'black';
           defaultIcon = /*#__PURE__*/React__default.createElement(Icon, _extends({
             icon: "exclamation-circle",
             type: "solid",
+            "aria-hidden": "true",
             className: clsxd(classes.icon)
           }, iconProps));
           break;
@@ -1282,10 +1368,11 @@
         case 'info':
           levers.wrapper = 'su-bg-digital-blue su-text-white su-link-white';
           levers.body = lightText;
-          levers.dismiss = lightText;
+          levers.dismiss = 'white';
           defaultIcon = /*#__PURE__*/React__default.createElement(Icon, _extends({
             icon: "information-circle",
             type: "solid",
+            "aria-hidden": "true",
             className: clsxd(classes.icon)
           }, iconProps));
           break;
@@ -1293,10 +1380,11 @@
         case 'error':
           levers.wrapper = 'su-bg-digital-red su-text-white su-link-white';
           levers.body = lightText;
-          levers.dismiss = lightText;
+          levers.dismiss = 'white';
           defaultIcon = /*#__PURE__*/React__default.createElement(Icon, _extends({
             icon: "ban",
             type: "solid",
+            "aria-hidden": "true",
             className: clsxd(classes.icon)
           }, iconProps));
           break;
@@ -1304,19 +1392,17 @@
     }
 
     var icon = (_props$icon = props.icon) != null ? _props$icon : defaultIcon;
-    var DefaultDismiss = /*#__PURE__*/React__default.createElement(Button, {
-      className: clsxd('su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest', levers.dismiss, classes.dismiss),
-      "aria-label": "Dismiss Alert",
+    var DefaultDismiss = /*#__PURE__*/React__default.createElement(DismissButton, {
+      text: "Dismiss",
       onClick: function onClick() {
         setDismissed(true);
       },
-      variant: "none",
-      size: "minimal"
-    }, "Dismiss ", /*#__PURE__*/React__default.createElement(Icon, {
-      icon: "x-circle",
-      type: "solid",
-      className: 'su-inline-block su-h-25 su-w-25'
-    }));
+      color: levers.dismiss,
+      classes: {
+        icon: 'su-ml-02em',
+        wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest su-mr-0 su-ml-auto'
+      }
+    });
     var dismissBtn = (_props$dismissBtn = props.dismissBtn) != null ? _props$dismissBtn : DefaultDismiss;
 
     if (isDismissed === true) {
@@ -1329,21 +1415,23 @@
     }, /*#__PURE__*/React__default.createElement("div", {
       className: clsxd('su-cc su-flex su-flex-wrap su-rs-py-1 sm:su-items-center', levers.container, classes.container)
     }, props.hasDismiss && /*#__PURE__*/React__default.createElement("div", {
-      className: clsxd('su-order-3 su-rs-ml-1 su-items-end su-flex-shrink su-text-right su-w-full sm:su-w-auto', levers.dismissWrapper, classes.dismissWrapper)
-    }, dismissBtn), /*#__PURE__*/React__default.createElement("div", {
-      className: clsxd('su-order-1 su-rs-mr-1 su-flex su-flex-shrink su-items-center su-mb-4 su-w-full su-pb-10 md:su-w-max', levers.headerWrapper, classes.headerWrapper)
+      className: clsxd('su-order-3 su-rs-ml-1 su-mt-15 sm:su-mt-0 su-items-center su-flex-shrink su-text-right su-w-full sm:su-w-auto', levers.dismissWrapper, classes.dismissWrapper)
+    }, dismissBtn), (props.hasIcon && !props.isIconTop || props.hasLabel && !props.isLabelTop) && /*#__PURE__*/React__default.createElement("div", {
+      className: clsxd('su-order-1 su-rs-mr-1 su-mb-15 md:su-mb-0 su-flex su-flex-shrink su-items-center su-w-full md:su-w-max', levers.headerWrapper, classes.headerWrapper)
     }, props.hasIcon && !props.isIconTop && /*#__PURE__*/React__default.createElement("span", {
       className: clsxd('su-mr-5 su-inline-block', levers.headerIcon, classes.headerIcon)
     }, icon), props.hasLabel && !props.isLabelTop && /*#__PURE__*/React__default.createElement("span", {
       className: clsxd('su-inline-block su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)
-    }, (_props$label = props.label) != null ? _props$label : 'Information')), /*#__PURE__*/React__default.createElement("div", {
+    }, (_props$label = props.label) != null ? _props$label : 'Alert:')), /*#__PURE__*/React__default.createElement("div", {
       className: clsxd('su-order-2 su-flex-1 su-flex-grow', levers.bodyWrapper, classes.bodyWrapper)
+    }, (props.hasIcon && props.isIconTop || props.hasLabel && props.isLabelTop) && /*#__PURE__*/React__default.createElement("div", {
+      className: "su-flex su-items-center su-rs-mb-0"
     }, props.hasIcon && props.isIconTop && /*#__PURE__*/React__default.createElement("span", {
-      className: clsxd('su-mr-5 su-text-left su-ml-0', levers.headerIcon, classes.headerIcon)
-    }, icon), props.hasLabel && props.isLabelTop && /*#__PURE__*/React__default.createElement("span", {
-      className: clsxd('su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)
-    }, (_props$label2 = props.label) != null ? _props$label2 : 'Information'), props.heading && /*#__PURE__*/React__default.createElement("h3", {
-      className: clsxd('su-type-2 su-mb-03em', levers.bodyHeading, classes.bodyHeading)
+      className: clsxd('su-inline-block su-mr-5 su-text-left su-ml-0', levers.headerIcon, classes.headerIcon)
+    }, icon), props.hasLabel && props.isLabelTop && /*#__PURE__*/React__default.createElement("div", {
+      className: clsxd('su-inline-block su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)
+    }, (_props$label2 = props.label) != null ? _props$label2 : 'Alert:')), props.heading && /*#__PURE__*/React__default.createElement("h3", {
+      className: clsxd('su-type-1 su-rs-mb-neg1', levers.bodyHeading, classes.bodyHeading)
     }, props.heading), /*#__PURE__*/React__default.createElement("div", {
       className: clsxd('su-text-normal', levers.body, classes.body)
     }, children), props.footer && /*#__PURE__*/React__default.createElement("div", {
@@ -1810,21 +1898,6 @@
     color: 'cardinal-red',
     type: 'short',
     isLink: true
-  };
-
-  var SrOnlyText = function SrOnlyText(props) {
-    var _props$srText;
-
-    var txt = (_props$srText = props.srText) != null ? _props$srText : '(link is external)';
-    return /*#__PURE__*/React__default.createElement("span", {
-      className: "su-sr-only"
-    }, txt);
-  };
-  SrOnlyText.propTypes = {
-    srText: propTypes.string
-  };
-  SrOnlyText.defaultProps = {
-    srText: '(link is external)'
   };
 
   var GlobalFooter = function GlobalFooter(_ref) {
@@ -2383,6 +2456,7 @@
   exports.Alert = Alert;
   exports.Button = Button;
   exports.Container = Container;
+  exports.DismissButton = DismissButton;
   exports.FlexBox = FlexBox;
   exports.FlexCell = FlexCell;
   exports.GlobalFooter = GlobalFooter;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27217,7 +27217,6 @@
       "integrity": "sha512-MvTmxrOSo+zZ5MaMx9LVWM8DlvVHeryCJKPJx8BYCEN38r8mIK7uCFYok8oMPmACrVe0MfXOdJCm1HKkBKjsMg==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.12.1",
         "@babel/generator": "^7.12.1",
         "@babel/parser": "^7.12.3",
         "@babel/plugin-transform-react-jsx": "^7.12.1",

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -16,7 +16,7 @@ import clsxd from 'clsx-dedupe';
 export const Alert = ({ classes = {}, children, ref, ...props }) => {
   // Defaults & Variables
   const levers = {};
-  const iconProps = { height: 24, width: 24 };
+  const iconProps = { height: 20, width: 20 };
   const [isDismissed, setDismissed] = useState(false);
 
   // Levers
@@ -111,7 +111,7 @@ export const Alert = ({ classes = {}, children, ref, ...props }) => {
         )}
 
         {/* Header Container. */}
-        <div className={clsxd('su-order-1 su-rs-mr-1 su-flex su-flex-shrink su-items-center su-mb-4 su-w-full su-pb-10 md:su-w-max', levers.headerWrapper, classes.headerWrapper)}>
+        <div className={clsxd('su-order-1 su-rs-mr-1 su-flex su-flex-shrink su-items-center su-w-full md:su-w-max', levers.headerWrapper, classes.headerWrapper)}>
           {(props.hasIcon && !props.isIconTop) && (
             <span className={clsxd('su-mr-5 su-inline-block', levers.headerIcon, classes.headerIcon)}>
               {icon}
@@ -135,9 +135,9 @@ export const Alert = ({ classes = {}, children, ref, ...props }) => {
           )}
 
           {(props.hasLabel && props.isLabelTop) && (
-            <span className={clsxd('su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)}>
+            <div className={clsxd('su-inline-block su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)}>
               {props.label ?? 'Information'}
-            </span>
+            </div>
           )}
 
           {props.heading && (

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -31,7 +31,7 @@ export const Alert = ({ classes = {}, children, ref, ...props }) => {
   }
 
   // Default Icon.
-  let defaultIcon = <Icon icon='bell' type='outline' className={clsxd({ 'su-inline-block': props.isIconTop }, classes.icon)} {...iconProps} />;
+  let defaultIcon = <Icon icon='bell' type='outline' aria-hidden='true' className={clsxd({ 'su-inline-block': props.isIconTop }, classes.icon)} {...iconProps} />;
 
   // Is Label Top
   if (props.isLabelTop) {
@@ -51,28 +51,28 @@ export const Alert = ({ classes = {}, children, ref, ...props }) => {
         levers.wrapper = 'su-bg-digital-green su-text-white su-link-white';
         levers.body = lightText;
         levers.dismiss = 'white';
-        defaultIcon = <Icon icon='check-circle' type='solid' className={clsxd(classes.icon)} {...iconProps} />;
+        defaultIcon = <Icon icon='check-circle' type='solid' aria-hidden='true' className={clsxd(classes.icon)} {...iconProps} />;
         break;
 
       case 'warning':
         levers.wrapper = 'su-bg-illuminating-dark';
         levers.body = darkText;
         levers.dismiss = 'black';
-        defaultIcon = <Icon icon='exclamation-circle' type='solid' className={clsxd(classes.icon)} {...iconProps} />;
+        defaultIcon = <Icon icon='exclamation-circle' type='solid' aria-hidden='true' className={clsxd(classes.icon)} {...iconProps} />;
         break;
 
       case 'info':
         levers.wrapper = 'su-bg-digital-blue su-text-white su-link-white';
         levers.body = lightText;
         levers.dismiss = 'white';
-        defaultIcon = <Icon icon='information-circle' type='solid' className={clsxd(classes.icon)} {...iconProps} />;
+        defaultIcon = <Icon icon='information-circle' type='solid' aria-hidden='true' className={clsxd(classes.icon)} {...iconProps} />;
         break;
 
       case 'error':
         levers.wrapper = 'su-bg-digital-red su-text-white su-link-white';
         levers.body = lightText;
         levers.dismiss = 'white';
-        defaultIcon = <Icon icon='ban' type='solid' className={clsxd(classes.icon)} {...iconProps} />;
+        defaultIcon = <Icon icon='ban' type='solid' aria-hidden='true' className={clsxd(classes.icon)} {...iconProps} />;
         break;
     }
   }
@@ -87,7 +87,7 @@ export const Alert = ({ classes = {}, children, ref, ...props }) => {
                    color={levers.dismiss}
                    classes={{
                      icon: 'su-ml-02em',
-                     wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest'
+                     wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest su-mr-0 su-ml-auto'
                    }}
     />
   );
@@ -105,13 +105,13 @@ export const Alert = ({ classes = {}, children, ref, ...props }) => {
       <div className={clsxd('su-cc su-flex su-flex-wrap su-rs-py-1 sm:su-items-center', levers.container, classes.container)}>
 
         {props.hasDismiss && (
-          <div className={clsxd('su-order-3 su-rs-ml-1 su-items-end su-flex-shrink su-text-right su-w-full sm:su-w-auto', levers.dismissWrapper, classes.dismissWrapper)}>
+          <div className={clsxd('su-order-3 su-rs-ml-1 su-mt-16 sm:su-mt-0 su-items-center su-flex-shrink su-text-right su-w-full sm:su-w-auto', levers.dismissWrapper, classes.dismissWrapper)}>
             {dismissBtn}
           </div>
         )}
 
         {/* Header Container. */}
-        <div className={clsxd('su-order-1 su-rs-mr-1 su-flex su-flex-shrink su-items-center su-w-full md:su-w-max', levers.headerWrapper, classes.headerWrapper)}>
+        <div className={clsxd('su-order-1 su-rs-mr-1 su-mb-16 md:su-mb-0 su-flex su-flex-shrink su-items-center su-w-full md:su-w-max', levers.headerWrapper, classes.headerWrapper)}>
           {(props.hasIcon && !props.isIconTop) && (
             <span className={clsxd('su-mr-5 su-inline-block', levers.headerIcon, classes.headerIcon)}>
               {icon}

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -40,28 +40,28 @@ export const Alert = ({ classes = {}, children, ref, ...props }) => {
         levers.wrapper = 'su-bg-digital-green su-text-white su-link-white';
         levers.body = lightText;
         levers.dismiss = 'white';
-        defaultIcon = <Icon icon='check-circle' type='solid' aria-hidden='true' className={clsxd(classes.icon)} {...iconProps} />;
+        defaultIcon = <Icon icon='check-circle' type='solid' aria-hidden='true' className={classes.icon} {...iconProps} />;
         break;
 
       case 'warning':
         levers.wrapper = 'su-bg-illuminating-dark';
         levers.body = darkText;
         levers.dismiss = 'black';
-        defaultIcon = <Icon icon='exclamation-circle' type='solid' aria-hidden='true' className={clsxd(classes.icon)} {...iconProps} />;
+        defaultIcon = <Icon icon='exclamation-circle' type='solid' aria-hidden='true' className={classes.icon} {...iconProps} />;
         break;
 
       case 'info':
         levers.wrapper = 'su-bg-digital-blue su-text-white su-link-white';
         levers.body = lightText;
         levers.dismiss = 'white';
-        defaultIcon = <Icon icon='information-circle' type='solid' aria-hidden='true' className={clsxd(classes.icon)} {...iconProps} />;
+        defaultIcon = <Icon icon='information-circle' type='solid' aria-hidden='true' className={classes.icon} {...iconProps} />;
         break;
 
       case 'error':
         levers.wrapper = 'su-bg-digital-red su-text-white su-link-white';
         levers.body = lightText;
         levers.dismiss = 'white';
-        defaultIcon = <Icon icon='ban' type='solid' aria-hidden='true' className={clsxd(classes.icon)} {...iconProps} />;
+        defaultIcon = <Icon icon='ban' type='solid' aria-hidden='true' className={classes.icon} {...iconProps} />;
         break;
     }
   }
@@ -74,10 +74,8 @@ export const Alert = ({ classes = {}, children, ref, ...props }) => {
     <DismissButton text='Dismiss'
                    onClick={() => { setDismissed(true); }}
                    color={levers.dismiss}
-                   classes={{
-                     icon: 'su-ml-02em',
-                     wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest su-mr-0 su-ml-auto'
-                   }}
+                   className='su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest su-mr-0 su-ml-auto'
+                   iconProps={{ className: 'su-ml-02em'}}
     />
   );
   const dismissBtn = props.dismissBtn ?? DefaultDismiss;

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -31,18 +31,7 @@ export const Alert = ({ classes = {}, children, ref, ...props }) => {
   }
 
   // Default Icon.
-  let defaultIcon = <Icon icon='bell' type='outline' aria-hidden='true' className={clsxd({ 'su-inline-block': props.isIconTop }, classes.icon)} {...iconProps} />;
-
-  // Is Label Top
-  if (props.isLabelTop) {
-    levers.label = clsxd('su-rs-mb-neg1', { 'su-inline-block': !props.isIconTop });
-    classes.icon = clsxd(classes.icon, 'su-inline-block');
-  }
-
-  // Is Icon Top but no label top.
-  if (props.isIconTop && !props.isLabelTop) {
-    levers.headerIcon = clsxd(levers.headerIcon, 'su-block su-rs-mb-neg1');
-  }
+  let defaultIcon = <Icon icon='bell' type='outline' aria-hidden='true' className={classes.icon} {...iconProps} />;
 
   // Props.type
   if (props.type && alertTypes.includes(props.type)) {
@@ -105,46 +94,54 @@ export const Alert = ({ classes = {}, children, ref, ...props }) => {
       <div className={clsxd('su-cc su-flex su-flex-wrap su-rs-py-1 sm:su-items-center', levers.container, classes.container)}>
 
         {props.hasDismiss && (
-          <div className={clsxd('su-order-3 su-rs-ml-1 su-mt-16 sm:su-mt-0 su-items-center su-flex-shrink su-text-right su-w-full sm:su-w-auto', levers.dismissWrapper, classes.dismissWrapper)}>
+          <div className={clsxd('su-order-3 su-rs-ml-1 su-mt-15 sm:su-mt-0 su-items-center su-flex-shrink su-text-right su-w-full sm:su-w-auto', levers.dismissWrapper, classes.dismissWrapper)}>
             {dismissBtn}
           </div>
         )}
 
         {/* Header Container. */}
-        <div className={clsxd('su-order-1 su-rs-mr-1 su-mb-16 md:su-mb-0 su-flex su-flex-shrink su-items-center su-w-full md:su-w-max', levers.headerWrapper, classes.headerWrapper)}>
-          {(props.hasIcon && !props.isIconTop) && (
-            <span className={clsxd('su-mr-5 su-inline-block', levers.headerIcon, classes.headerIcon)}>
+        {((props.hasIcon && !props.isIconTop) || (props.hasLabel && !props.isLabelTop)) &&
+          <div
+            className={clsxd('su-order-1 su-rs-mr-1 su-mb-15 md:su-mb-0 su-flex su-flex-shrink su-items-center su-w-full md:su-w-max', levers.headerWrapper, classes.headerWrapper)}>
+            {(props.hasIcon && !props.isIconTop) && (
+              <span className={clsxd('su-mr-5 su-inline-block', levers.headerIcon, classes.headerIcon)}>
               {icon}
             </span>
-          )}
+            )}
 
-          {(props.hasLabel && !props.isLabelTop) && (
-            <span className={clsxd('su-inline-block su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)}>
-              {props.label ?? 'Information'}
+            {(props.hasLabel && !props.isLabelTop) && (
+              <span className={clsxd('su-inline-block su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)}>
+              {props.label ?? 'Alert:'}
             </span>
-          )}
-        </div>
+            )}
+          </div>
+        }
 
         {/* Body Container. */}
         <div className={clsxd('su-order-2 su-flex-1 su-flex-grow', levers.bodyWrapper, classes.bodyWrapper)}>
 
-          {(props.hasIcon && props.isIconTop) && (
-            <span className={clsxd('su-mr-5 su-text-left su-ml-0', levers.headerIcon, classes.headerIcon)}>
-              {icon}
-            </span>
-          )}
+          {((props.hasIcon && props.isIconTop) || (props.hasLabel && props.isLabelTop)) &&
+            <div className='su-flex su-items-center su-rs-mb-0'>
+              {(props.hasIcon && props.isIconTop) && (
+                <span className={clsxd('su-inline-block su-mr-5 su-text-left su-ml-0', levers.headerIcon, classes.headerIcon)}>
+                {icon}
+              </span>
+              )}
 
-          {(props.hasLabel && props.isLabelTop) && (
-            <div className={clsxd('su-inline-block su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)}>
-              {props.label ?? 'Information'}
+              {(props.hasLabel && props.isLabelTop) && (
+                <div className={clsxd('su-inline-block su-uppercase su-font-bold su-text-17 su-tracking-widest', levers.label, classes.label)}>
+                  {props.label ?? 'Alert:'}
+                </div>
+              )}
             </div>
-          )}
+          }
 
           {props.heading && (
-            <h3 className={clsxd('su-type-2 su-mb-03em', levers.bodyHeading, classes.bodyHeading)}>
+            <h3 className={clsxd('su-type-1 su-rs-mb-neg1', levers.bodyHeading, classes.bodyHeading)}>
               {props.heading}
             </h3>
           )}
+
 
           <div className={clsxd('su-text-normal', levers.body, classes.body)}>
             {children}

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { alertTypes, lightText, darkText } from './Alert.levers';
-import { Button } from '../Button/Button';
+import { DismissButton } from '../DismissButton/DismissButton';
 import Icon from 'react-hero-icon';
 import clsxd from 'clsx-dedupe';
 
@@ -22,7 +22,7 @@ export const Alert = ({ classes = {}, children, ref, ...props }) => {
   // Levers
   // ---------------------------------------------------------------------------
   levers.wrapper = 'su-bg-foggy-light';
-  levers.dismiss = clsxd(darkText, 'hover:su-text-black focus:su-text-black');
+  levers.dismiss = 'black';
 
   // Is large Icon.
   if (props.isLargeIcon) {
@@ -50,28 +50,28 @@ export const Alert = ({ classes = {}, children, ref, ...props }) => {
       case 'success':
         levers.wrapper = 'su-bg-digital-green su-text-white su-link-white';
         levers.body = lightText;
-        levers.dismiss = lightText;
+        levers.dismiss = 'white';
         defaultIcon = <Icon icon='check-circle' type='solid' className={clsxd(classes.icon)} {...iconProps} />;
         break;
 
       case 'warning':
         levers.wrapper = 'su-bg-illuminating-dark';
         levers.body = darkText;
-        levers.dismiss = clsxd(darkText, 'hover:su-text-black');
+        levers.dismiss = 'black';
         defaultIcon = <Icon icon='exclamation-circle' type='solid' className={clsxd(classes.icon)} {...iconProps} />;
         break;
 
       case 'info':
         levers.wrapper = 'su-bg-digital-blue su-text-white su-link-white';
         levers.body = lightText;
-        levers.dismiss = lightText;
+        levers.dismiss = 'white';
         defaultIcon = <Icon icon='information-circle' type='solid' className={clsxd(classes.icon)} {...iconProps} />;
         break;
 
       case 'error':
         levers.wrapper = 'su-bg-digital-red su-text-white su-link-white';
         levers.body = lightText;
-        levers.dismiss = lightText;
+        levers.dismiss = 'white';
         defaultIcon = <Icon icon='ban' type='solid' className={clsxd(classes.icon)} {...iconProps} />;
         break;
     }
@@ -82,19 +82,14 @@ export const Alert = ({ classes = {}, children, ref, ...props }) => {
 
   const icon = props.icon ?? defaultIcon;
   const DefaultDismiss = (
-    <Button
-      className={clsxd(
-        'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest',
-        levers.dismiss,
-        classes.dismiss
-      )}
-      aria-label='Dismiss Alert'
-      onClick={() => { setDismissed(true); }}
-      variant='none'
-      size='minimal'
-    >
-      Dismiss <Icon icon='x-circle' type='solid' className={'su-inline-block su-h-25 su-w-25'} />
-    </Button>
+    <DismissButton text='Dismiss'
+                   onClick={() => { setDismissed(true); }}
+                   color={levers.dismiss}
+                   classes={{
+                     icon: 'su-ml-02em',
+                     wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest'
+                   }}
+    />
   );
   const dismissBtn = props.dismissBtn ?? DefaultDismiss;
 

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -6,9 +6,9 @@ import { alertTypes } from './Alert.levers';
 import { textMixed } from '../../.storybook/stories/Paragraph.stories';
 import DOMPurify from 'dompurify';
 
-const alertBody = "<p class='last:su-mb-0 su-leading-display su-card-paragraph'>A <strong>paragraph</strong> (from the Greek paragraphos, <em>“to write beside”</em> or “<i>written beside</i>”) is a <a href=\"#\">self-contained unit of a discourse</a> in writing dealing with a <span class=\"su-underline\">particular point or idea</span>.</p>";
+const alertBody = '<p class="last:su-mb-0 su-leading-display su-card-paragraph">A <strong>paragraph</strong> (from the Greek paragraphos, <em>“to write beside”</em> or “<i>written beside</i>”) is a <a href=\"#\">self-contained unit of a discourse</a> in writing dealing with a <span class=\"su-underline\">particular point or idea</span>.</p>';
 
-const alertBodyShort = "<p class='last:su-mb-0 su-leading-display su-card-paragraph'>A <strong>paragraph</strong> (from the Greek paragraphos, <em>“to write beside”</em> or “<i>written beside</i>”) is a <a href=\"#\">self-contained</a> unit of a discourse.</p>";
+const alertBodyShort = '<p class="last:su-mb-0 su-leading-display su-card-paragraph">For displaying a notification that keeps people informed of a status.</p>';
 
 export default {
   title: 'Composite/Alert',

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -6,6 +6,10 @@ import { alertTypes } from './Alert.levers';
 import { textMixed } from '../../.storybook/stories/Paragraph.stories';
 import DOMPurify from 'dompurify';
 
+const alertBody = "<p class='last:su-mb-0 su-leading-display su-card-paragraph'>A <strong>paragraph</strong> (from the Greek paragraphos, <em>“to write beside”</em> or “<i>written beside</i>”) is a <a href=\"#\">self-contained unit of a discourse</a> in writing dealing with a <span class=\"su-underline\">particular point or idea</span>.</p>";
+
+const alertBodyShort = "<p class='last:su-mb-0 su-leading-display su-card-paragraph'>A <strong>paragraph</strong> (from the Greek paragraphos, <em>“to write beside”</em> or “<i>written beside</i>”) is a <a href=\"#\">self-contained</a> unit of a discourse.</p>";
+
 export default {
   title: 'Composite/Alert',
   decorators: [withDesign],
@@ -45,12 +49,12 @@ const AlertTemplate = ({ children, ...rest }) => {
 // /////////////////////////////////////////////////////////////////////////////
 export const Default = AlertTemplate.bind({});
 Default.args = {
-  children: textMixed
+  children: alertBodyShort
 };
 
 export const Info = AlertTemplate.bind({});
 Info.args = {
-  children: textMixed,
+  children: alertBodyShort,
   type: 'info'
 };
 
@@ -65,7 +69,7 @@ Info.parameters = {
 
 export const Error = AlertTemplate.bind({});
 Error.args = {
-  children: textMixed,
+  children: alertBody,
   type: 'error',
   label: 'error'
 };
@@ -79,7 +83,7 @@ Error.parameters = {
 
 export const Warning = AlertTemplate.bind({});
 Warning.args = {
-  children: textMixed,
+  children: alertBody,
   type: 'warning',
   label: 'warning'
 };
@@ -93,7 +97,7 @@ Warning.parameters = {
 
 export const Success = AlertTemplate.bind({});
 Success.args = {
-  children: textMixed,
+  children: alertBody,
   type: 'success',
   label: 'success'
 };
@@ -107,14 +111,14 @@ Success.parameters = {
 
 export const LabelsOnTop = AlertTemplate.bind({});
 LabelsOnTop.args = {
-  children: textMixed,
+  children: alertBody,
   isIconTop: true,
   isLabelTop: true
 };
 
 export const NoDismiss = AlertTemplate.bind({});
 NoDismiss.args = {
-  children: textMixed,
+  children: alertBody,
   heading: 'Alert Lorem Ipsum',
   hasDismiss: false
 };
@@ -122,7 +126,7 @@ NoDismiss.storyName = 'No Dismiss Button';
 
 export const BigIcon = AlertTemplate.bind({});
 BigIcon.args = {
-  children: textMixed,
+  children: alertBody,
   heading: 'Alert Lorem Ipsum',
   hasLabel: false,
   isLargeIcon: true

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -6,7 +6,7 @@ import { alertTypes } from './Alert.levers';
 import { textMixed } from '../../.storybook/stories/Paragraph.stories';
 import DOMPurify from 'dompurify';
 
-const alertBody = '<p class="last:su-mb-0 su-leading-display su-card-paragraph">A <strong>paragraph</strong> (from the Greek paragraphos, <em>“to write beside”</em> or “<i>written beside</i>”) is a <a href=\"#\">self-contained unit of a discourse</a> in writing dealing with a <span class=\"su-underline\">particular point or idea</span>.</p>';
+const alertBody = '<p class="last:su-mb-0 su-leading-display su-card-paragraph">A <strong>paragraph</strong> (from the Greek paragraphos, <em>“to write beside”</em> or “<i>written beside</i>”) is a <a href=\"#\">self-contained unit of a discourse</a> in writing dealing with a particular point or idea.</p>';
 
 const alertBodyShort = '<p class="last:su-mb-0 su-leading-display su-card-paragraph">For displaying a notification that keeps people informed of a status.</p>';
 
@@ -55,7 +55,8 @@ Default.args = {
 export const Info = AlertTemplate.bind({});
 Info.args = {
   children: alertBodyShort,
-  type: 'info'
+  type: 'info',
+  label: 'information:'
 };
 
 // Supports Markdown.
@@ -71,7 +72,7 @@ export const Error = AlertTemplate.bind({});
 Error.args = {
   children: alertBody,
   type: 'error',
-  label: 'error'
+  label: 'error:'
 };
 Error.parameters = {
   docs: {
@@ -85,7 +86,7 @@ export const Warning = AlertTemplate.bind({});
 Warning.args = {
   children: alertBody,
   type: 'warning',
-  label: 'warning'
+  label: 'warning:'
 };
 Warning.parameters = {
   docs: {
@@ -99,7 +100,7 @@ export const Success = AlertTemplate.bind({});
 Success.args = {
   children: alertBody,
   type: 'success',
-  label: 'success'
+  label: 'success:'
 };
 Success.parameters = {
   docs: {
@@ -116,14 +117,6 @@ LabelsOnTop.args = {
   isLabelTop: true
 };
 
-export const NoDismiss = AlertTemplate.bind({});
-NoDismiss.args = {
-  children: alertBody,
-  heading: 'Alert Lorem Ipsum',
-  hasDismiss: false
-};
-NoDismiss.storyName = 'No Dismiss Button';
-
 export const BigIcon = AlertTemplate.bind({});
 BigIcon.args = {
   children: alertBody,
@@ -131,12 +124,22 @@ BigIcon.args = {
   hasLabel: false,
   isLargeIcon: true
 };
-BigIcon.storyName = 'Big Icon + No Label';
+BigIcon.storyName = 'Big Icon + Big Heading ';
 
-export const WithHeader = AlertTemplate.bind({});
-WithHeader.args = {
-  heading: 'Alert Lorem Ipsum',
-  children: textMixed,
+export const BigIconLabel = AlertTemplate.bind({});
+BigIconLabel.args = {
+  children: alertBody,
+  type: 'info',
+  label: 'information:',
   isLabelTop: true,
   isLargeIcon: true
 };
+BigIconLabel.storyName = 'Big Icon + Top Label';
+
+
+export const NoDismiss = AlertTemplate.bind({});
+NoDismiss.args = {
+  children: alertBody,
+  hasDismiss: false
+};
+NoDismiss.storyName = 'No Dismiss Button';

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { withDesign } from 'storybook-addon-designs';
 import { Alert } from './Alert';
-import { Button } from '../Button/Button';
+import { DismissButton } from '../DismissButton/DismissButton';
 import { alertTypes } from './Alert.levers';
 import { textMixed } from '../../.storybook/stories/Paragraph.stories';
 import DOMPurify from 'dompurify';
@@ -10,7 +10,7 @@ export default {
   title: 'Composite/Alert',
   decorators: [withDesign],
   component: Alert,
-  subcomponents: { Button },
+  subcomponents: { DismissButton },
   parameters: {
     design: {
       type: 'figma',

--- a/src/DismissButton/DismissButton.js
+++ b/src/DismissButton/DismissButton.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { dismissIconOptions, dismissIconTypes, dismissIconColors } from './DismissButton.levers';
+import { Button } from '../Button/Button';
+import { SrOnlyText } from "../SrOnlyText/SrOnlyText";
+import Icon from 'react-hero-icon';
+import clsxd from 'clsx-dedupe';
+
+/**
+ * Dismiss Button Component
+ *
+ * For use with other components such as DismissButtons and modals.
+ *
+ */
+export const DismissButton = ({ classes = {}, text, srText, color, icon, iconType, customIcon, onClick, ...props }) => {
+  // Defaults & Variables
+  const levers = {};
+  const iconProps = { height: 20, width: 20 };
+
+  // Levers
+  // ---------------------------------------------------------------------------
+
+  // color
+  if (color && dismissIconColors.includes(color)) {
+    switch (color) {
+      case 'black':
+        levers.color = 'su-text-black hocus:su-text-black';
+        break;
+
+      case 'white':
+        levers.color = 'su-text-white hocus:su-text-white';
+        break;
+    }
+  }
+
+  // Dismiss Icon and defaults
+  // Set heroicon and icon type if not specified
+
+  let heroicon = '';
+
+  if (icon && dismissIconOptions.includes(icon)) {
+    heroicon = icon;
+  }
+
+  let heroiconType = 'solid';
+
+  if (iconType && dismissIconTypes.includes(iconType)) {
+    heroiconType = iconType;
+  }
+
+  // Set default heroicon if custom icon element isn't provided
+  const defaultIcon = <Icon icon={heroicon} type={heroiconType} aria-hidden='true' className={clsxd('su-ml-02em', classes.icon)} {...iconProps} />;
+
+  // Use custom icon for the component if it's provided; if not, use the default heroicon
+  const dismissIcon = customIcon ?? defaultIcon;
+
+  return (
+    <Button
+      variant='none'
+      size='minimal'
+      className={clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display',
+        levers.color,
+        classes.wrapper
+      )}
+      onClick={onClick}
+      {...props}
+    >
+      {text && text}
+      {srText &&
+        <SrOnlyText srText={' ' + srText} />
+      }
+      {dismissIcon}
+    </Button>
+  );
+};
+
+// Prop Types.
+// -----------------------------------------------------------------------------
+
+DismissButton.propTypes = {
+  text: PropTypes.string,
+  srText: PropTypes.string,
+  color: PropTypes.oneOf(dismissIconColors),
+  icon: PropTypes.oneOf(dismissIconOptions),
+  iconType: PropTypes.oneOf(dismissIconTypes),
+  customIcon: PropTypes.element,
+  onClick: PropTypes.func,
+
+  // The CSS Classname property
+  classes: PropTypes.shape(
+    {
+      wrapper: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object,
+        PropTypes.array
+      ]),
+      icon: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object,
+        PropTypes.array
+      ]),
+    }
+  )
+};
+
+// Default Props.
+// -----------------------------------------------------------------------------
+DismissButton.defaultProps = {
+  color: 'black',
+  icon: 'x-circle',
+  iconType: 'solid'
+};

--- a/src/DismissButton/DismissButton.js
+++ b/src/DismissButton/DismissButton.js
@@ -110,6 +110,10 @@ DismissButton.propTypes = {
    */
   onClick: PropTypes.func,
 
+  /**
+   * Props for the Icon Element.
+   */ 
+  iconProps: PropTypes.object,
 
 // Default Props.
 // -----------------------------------------------------------------------------

--- a/src/DismissButton/DismissButton.js
+++ b/src/DismissButton/DismissButton.js
@@ -58,14 +58,11 @@ export const DismissButton = ({ classes = {}, text, srText, color, icon, iconTyp
     <Button
       variant='none'
       size='minimal'
-      className={clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display',
-        levers.color,
-        classes.wrapper
-      )}
+      className={clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display', levers.color, classes.wrapper)}
       onClick={onClick}
       {...props}
     >
-      {text && text}
+      {text}
       {srText &&
         <SrOnlyText srText={' ' + srText} />
       }
@@ -78,15 +75,44 @@ export const DismissButton = ({ classes = {}, text, srText, color, icon, iconTyp
 // -----------------------------------------------------------------------------
 
 DismissButton.propTypes = {
+  /**
+   * Button text
+   */
   text: PropTypes.string,
+
+  /**
+   * Screen reader only text (required for icon buttons)
+   */
   srText: PropTypes.string,
+
+  /**
+   * Color of the text and icon
+   */
   color: PropTypes.oneOf(dismissIconColors),
+
+  /**
+   * Heroicon option
+   */
   icon: PropTypes.oneOf(dismissIconOptions),
+
+  /**
+   * Heroicon type
+   */
   iconType: PropTypes.oneOf(dismissIconTypes),
+
+  /**
+   * If you want to provide your own custom icon element
+   */
   customIcon: PropTypes.element,
+
+  /**
+   * onClick function
+   */
   onClick: PropTypes.func,
 
-  // The CSS Classname property
+  /**
+   * Additional classes for styling
+   */
   classes: PropTypes.shape(
     {
       wrapper: PropTypes.oneOfType([

--- a/src/DismissButton/DismissButton.js
+++ b/src/DismissButton/DismissButton.js
@@ -49,7 +49,7 @@ export const DismissButton = ({ classes = {}, text, srText, color, icon, iconTyp
   }
 
   // Set default heroicon if custom icon element isn't provided
-  const defaultIcon = <Icon icon={heroicon} type={heroiconType} aria-hidden='true' className={clsxd('su-ml-02em', classes.icon)} {...iconProps} />;
+  const defaultIcon = <Icon icon={heroicon} type={heroiconType} aria-hidden='true' className={classes.icon} {...iconProps} />;
 
   // Use custom icon for the component if it's provided; if not, use the default heroicon
   const dismissIcon = customIcon ?? defaultIcon;

--- a/src/DismissButton/DismissButton.js
+++ b/src/DismissButton/DismissButton.js
@@ -15,7 +15,7 @@ import clsxd from 'clsx-dedupe';
 export const DismissButton = ({ className, text, srText, color, icon, iconType, iconSize, iconProps, customIcon, onClick, ...props }) => {
   // Defaults & Variables
   const levers = {};
-  iconProps = Object.assign({ height: iconSize ?? 20, width: iconSize ?? 20 }, {...iconProps});
+  iconProps = { height: iconSize ?? 20, width: iconSize ?? 20, ...iconProps };
 
   // Levers
   // ---------------------------------------------------------------------------

--- a/src/DismissButton/DismissButton.js
+++ b/src/DismissButton/DismissButton.js
@@ -12,10 +12,10 @@ import clsxd from 'clsx-dedupe';
  * For use with other components such as DismissButtons and modals.
  *
  */
-export const DismissButton = ({ className, text, srText, color, icon, iconType, iconProps, customIcon, onClick, ...props }) => {
+export const DismissButton = ({ className, text, srText, color, icon, iconType, iconSize, iconProps, customIcon, onClick, ...props }) => {
   // Defaults & Variables
   const levers = {};
-  iconProps = Object.assign({ height: 20, width: 20 }, {...iconProps});
+  iconProps = Object.assign({ height: iconSize ?? 20, width: iconSize ?? 20 }, {...iconProps});
 
   // Levers
   // ---------------------------------------------------------------------------
@@ -114,6 +114,11 @@ DismissButton.propTypes = {
    * Props for the Icon Element.
    */
   iconProps: PropTypes.object,
+
+  /**
+   * Size (same for height and width) of the icon in pixels.
+   */
+  iconSize: PropTypes.number,
 
   /**
    * Custom CSS classes, e.g., to change color

--- a/src/DismissButton/DismissButton.js
+++ b/src/DismissButton/DismissButton.js
@@ -110,24 +110,6 @@ DismissButton.propTypes = {
    */
   onClick: PropTypes.func,
 
-  /**
-   * Additional classes for styling
-   */
-  classes: PropTypes.shape(
-    {
-      wrapper: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.object,
-        PropTypes.array
-      ]),
-      icon: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.object,
-        PropTypes.array
-      ]),
-    }
-  )
-};
 
 // Default Props.
 // -----------------------------------------------------------------------------

--- a/src/DismissButton/DismissButton.js
+++ b/src/DismissButton/DismissButton.js
@@ -15,7 +15,7 @@ import clsxd from 'clsx-dedupe';
 export const DismissButton = ({ className, text, srText, color, icon, iconType, iconProps, customIcon, onClick, ...props }) => {
   // Defaults & Variables
   const levers = {};
-  const iconProps = { height: 20, width: 20 };
+  iconProps = Object.assign({ height: 20, width: 20 }, ...iconProps);
 
   // Levers
   // ---------------------------------------------------------------------------

--- a/src/DismissButton/DismissButton.js
+++ b/src/DismissButton/DismissButton.js
@@ -12,7 +12,7 @@ import clsxd from 'clsx-dedupe';
  * For use with other components such as DismissButtons and modals.
  *
  */
-export const DismissButton = ({ classes = {}, text, srText, color, icon, iconType, customIcon, onClick, ...props }) => {
+export const DismissButton = ({ className, text, srText, color, icon, iconType, iconProps, customIcon, onClick, ...props }) => {
   // Defaults & Variables
   const levers = {};
   const iconProps = { height: 20, width: 20 };

--- a/src/DismissButton/DismissButton.js
+++ b/src/DismissButton/DismissButton.js
@@ -49,7 +49,7 @@ export const DismissButton = ({ className, text, srText, color, icon, iconType, 
   }
 
   // Set default heroicon if custom icon element isn't provided
-  const defaultIcon = <Icon icon={heroicon} type={heroiconType} aria-hidden='true' className={classes.icon} {...iconProps} />;
+  const defaultIcon = <Icon icon={heroicon} type={heroiconType} aria-hidden='true' {...iconProps} />;
 
   // Use custom icon for the component if it's provided; if not, use the default heroicon
   const dismissIcon = customIcon ?? defaultIcon;

--- a/src/DismissButton/DismissButton.js
+++ b/src/DismissButton/DismissButton.js
@@ -15,7 +15,7 @@ import clsxd from 'clsx-dedupe';
 export const DismissButton = ({ className, text, srText, color, icon, iconType, iconProps, customIcon, onClick, ...props }) => {
   // Defaults & Variables
   const levers = {};
-  iconProps = Object.assign({ height: 20, width: 20 }, ...iconProps);
+  iconProps = Object.assign({ height: 20, width: 20 }, {...iconProps});
 
   // Levers
   // ---------------------------------------------------------------------------
@@ -112,8 +112,18 @@ DismissButton.propTypes = {
 
   /**
    * Props for the Icon Element.
-   */ 
+   */
   iconProps: PropTypes.object,
+
+  /**
+   * Custom CSS classes, e.g., to change color
+   */
+  className: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array,
+    PropTypes.object
+  ]),
+};
 
 // Default Props.
 // -----------------------------------------------------------------------------

--- a/src/DismissButton/DismissButton.js
+++ b/src/DismissButton/DismissButton.js
@@ -58,7 +58,7 @@ export const DismissButton = ({ className, text, srText, color, icon, iconType, 
     <Button
       variant='none'
       size='minimal'
-      className={clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display', levers.color, classes.wrapper)}
+      className={clsxd('su-flex su-items-center su-w-fit su-sans su-font-semibold su-leading-display', levers.color, className)}
       onClick={onClick}
       {...props}
     >

--- a/src/DismissButton/DismissButton.levers.js
+++ b/src/DismissButton/DismissButton.levers.js
@@ -1,0 +1,15 @@
+/**
+ * Text and icon color for the dismiss button
+ */
+export const dismissIconColors = ['black', 'white', 'unset'];
+
+/**
+ * Heroicon options for the Dismiss Button
+ */
+export const dismissIconOptions = ['x-circle', 'x', 'none'];
+
+/**
+ * Heroicon type for the Dismiss Button
+ */
+export const dismissIconTypes = ['solid', 'outline'];
+

--- a/src/DismissButton/DismissButton.stories.js
+++ b/src/DismissButton/DismissButton.stories.js
@@ -42,10 +42,10 @@ const DismissButtonTemplate = ({ ...rest }) => {
 export const Default = DismissButtonTemplate.bind({});
 Default.args = {
   text: 'Dismiss',
-  classes: {
-    wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest',
-    icon: 'su-ml-02em'
-  }
+  className: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest',
+  iconProps: {
+    className: 'su-ml-02em'
+  },
 };
 Default.storyName = 'Alert Dismiss Button (Dark)';
 
@@ -54,9 +54,9 @@ Close.args = {
   text: 'Close',
   icon: 'x',
   iconType: 'solid',
-  classes: {
-    icon: 'su-ml-02em'
-  }
+  iconProps: {
+    className: 'su-ml-02em'
+  },
 };
 Close.storyName = 'Close Button with X Icon';
 

--- a/src/DismissButton/DismissButton.stories.js
+++ b/src/DismissButton/DismissButton.stories.js
@@ -67,3 +67,15 @@ SrText.args = {
   iconType: 'solid',
 };
 SrText.storyName = 'Icon Button with Screen Reader Only Text';
+
+export const CustomSize = DismissButtonTemplate.bind({});
+CustomSize.args = {
+  srText: 'Close Modal',
+  icon: 'x-circle',
+  iconType: 'solid',
+  iconSize: 60,
+  iconProps: {
+    className: 'su-text-sky-dark hocus:su-text-plum'
+  },
+};
+CustomSize.storyName = 'Large Icon Button with Custom Color';

--- a/src/DismissButton/DismissButton.stories.js
+++ b/src/DismissButton/DismissButton.stories.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { DismissButton } from './DismissButton';
+import { Button } from '../Button/Button';
+import { dismissIconOptions, dismissIconTypes, dismissIconColors } from './DismissButton.levers';
+import { SrOnlyText } from '../SrOnlyText/SrOnlyText';
+
+export default {
+  title: 'Simple/Dismiss Button',
+  component: DismissButton,
+  subcomponents: { Button, SrOnlyText },
+  argTypes: {
+    color: {
+      control: {
+        type: 'inline-radio',
+        options: dismissIconColors
+      }
+    },
+    icon: {
+      control: {
+        type: 'inline-radio',
+        options: dismissIconOptions
+      }
+    },
+    iconType: {
+      control: {
+        type: 'inline-radio',
+        options: dismissIconTypes
+      }
+    },
+    onClick: {
+      action: 'clicked'
+    }
+  }
+};
+
+const DismissButtonTemplate = ({ ...rest }) => {
+  return (
+    <DismissButton {...rest} />
+  );
+};
+
+export const Default = DismissButtonTemplate.bind({});
+Default.args = {
+  text: 'Dismiss',
+  classes: {
+    wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest'
+  }
+};
+Default.storyName = 'Alert Dismiss Button (Dark)';
+
+export const Close = DismissButtonTemplate.bind({});
+Close.args = {
+  text: 'Close',
+  icon: 'x',
+  iconType: 'solid'
+};
+Close.storyName = 'Close Button with X Icon';
+
+export const SrText = DismissButtonTemplate.bind({});
+SrText.args = {
+  SrText: 'Close Modal',
+  icon: 'x',
+  iconType: 'solid'
+};
+SrText.storyName = 'Icon Button with Screen Reader Only Text';

--- a/src/DismissButton/DismissButton.stories.js
+++ b/src/DismissButton/DismissButton.stories.js
@@ -27,6 +27,14 @@ export default {
         options: dismissIconTypes
       }
     },
+    iconSize: {
+      control: {
+        type: 'range',
+        min: 16,
+        max: 100,
+        step: 1
+      }
+    },
     onClick: {
       action: 'clicked'
     }

--- a/src/DismissButton/DismissButton.stories.js
+++ b/src/DismissButton/DismissButton.stories.js
@@ -43,7 +43,8 @@ export const Default = DismissButtonTemplate.bind({});
 Default.args = {
   text: 'Dismiss',
   classes: {
-    wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest'
+    wrapper: 'su-text-17 su-uppercase su-font-bold su-inline-block su-tracking-widest',
+    icon: 'su-ml-02em'
   }
 };
 Default.storyName = 'Alert Dismiss Button (Dark)';
@@ -52,14 +53,17 @@ export const Close = DismissButtonTemplate.bind({});
 Close.args = {
   text: 'Close',
   icon: 'x',
-  iconType: 'solid'
+  iconType: 'solid',
+  classes: {
+    icon: 'su-ml-02em'
+  }
 };
 Close.storyName = 'Close Button with X Icon';
 
 export const SrText = DismissButtonTemplate.bind({});
 SrText.args = {
-  SrText: 'Close Modal',
+  srText: 'Close Modal',
   icon: 'x',
-  iconType: 'solid'
+  iconType: 'solid',
 };
 SrText.storyName = 'Icon Button with Screen Reader Only Text';

--- a/src/DismissButton/DismissButton.test.js
+++ b/src/DismissButton/DismissButton.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { DismissButton } from './DismissButton';
+
+// Component is a component.
+describe('DismissButton', () => {
+  // Is a component with valid syntax.
+  it('is truthy', () => {
+    expect(DismissButton).toBeTruthy();
+  });
+
+  // Default is rendered.
+  it('renders the Button in the default state', () => {
+    render(<DismissButton text='Test Text' />);
+    screen.getByText('Test Text'); // full string match
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { Alert } from './Alert/Alert';
 import { Button } from './Button/Button';
 import { Container } from './Container/Container';
+import { DismissButton } from './DismissButton/DismissButton';
 import { FlexBox } from './FlexBox/FlexBox';
 import { FlexCell } from './FlexCell/FlexCell';
 import { Heading } from './Heading/Heading';
@@ -15,4 +16,4 @@ import { Skiplink } from './Skiplink/Skiplink';
 import { SrOnlyText } from './SrOnlyText/SrOnlyText';
 import { StyledLink } from './StyledLink';
 
-export { Alert, Button, Container, FlexBox, FlexCell, GlobalFooter, Grid, GridCell, Heading, IdentityBar, LocalFooter, Lockup, Logo, Skiplink, SrOnlyText, StyledLink };
+export { Alert, Button, Container, DismissButton, FlexBox, FlexCell, GlobalFooter, Grid, GridCell, Heading, IdentityBar, LocalFooter, Lockup, Logo, Skiplink, SrOnlyText, StyledLink };


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add Dismiss Button as its own component since we often need one in modals and other components.
- Use it in the Alert component

# Needed By (Date)
- When does this need to be merged by?

# Urgency
- How critical is this PR?

# Steps to Test

1. Look at code
1. Look at preview build and see the Dismiss Button examples
2. Look at the Alert component and see that alignment of labels, content, dismiss button should be improved. Also spacing has been tweaked - please check the different examples at different breakpoints.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
