### PR TITLE
ADAPT-2140: Add support for forwarding refs to button component.

### DIFF
--- a/dist/decanter-react.js
+++ b/dist/decanter-react.js
@@ -1259,7 +1259,7 @@ var getIconAnimation = function getIconAnimation(animate) {
   return classes;
 };
 
-var Button = function Button(_ref) {
+var Button = /*#__PURE__*/React__default.forwardRef(function (_ref, ref) {
   var className = _ref.className,
       children = _ref.children,
       onClick = _ref.onClick,
@@ -1330,14 +1330,15 @@ var Button = function Button(_ref) {
     className: cnbuilder.dcnb('su-button su-group su-leading-display', levers.variant, levers.size, levers.disabled, className),
     onClick: onClick,
     type: type,
-    disabled: isDisabled
+    disabled: isDisabled,
+    ref: ref
   }, props), children, icon && /*#__PURE__*/React__default.createElement(Icon, _extends({
     icon: heroicon,
     type: "solid",
     "aria-hidden": true,
     className: cnbuilder.dcnb('su-inline-block', levers.icon, levers.animate, iconClasses)
   }, iProps)));
-};
+});
 Button.propTypes = {
   type: propTypes.oneOf(buttonTypes),
   variant: propTypes.oneOf(buttonVariants),

--- a/dist/decanter-react.modern.js
+++ b/dist/decanter-react.modern.js
@@ -1256,7 +1256,7 @@ var getIconAnimation = function getIconAnimation(animate) {
   return classes;
 };
 
-var Button = function Button(_ref) {
+var Button = /*#__PURE__*/React.forwardRef(function (_ref, ref) {
   var className = _ref.className,
       children = _ref.children,
       onClick = _ref.onClick,
@@ -1327,14 +1327,15 @@ var Button = function Button(_ref) {
     className: dcnb('su-button su-group su-leading-display', levers.variant, levers.size, levers.disabled, className),
     onClick: onClick,
     type: type,
-    disabled: isDisabled
+    disabled: isDisabled,
+    ref: ref
   }, props), children, icon && /*#__PURE__*/React.createElement(Icon, _extends({
     icon: heroicon,
     type: "solid",
     "aria-hidden": true,
     className: dcnb('su-inline-block', levers.icon, levers.animate, iconClasses)
   }, iProps)));
-};
+});
 Button.propTypes = {
   type: propTypes.oneOf(buttonTypes),
   variant: propTypes.oneOf(buttonVariants),

--- a/dist/decanter-react.module.js
+++ b/dist/decanter-react.module.js
@@ -1256,7 +1256,7 @@ var getIconAnimation = function getIconAnimation(animate) {
   return classes;
 };
 
-var Button = function Button(_ref) {
+var Button = /*#__PURE__*/React.forwardRef(function (_ref, ref) {
   var className = _ref.className,
       children = _ref.children,
       onClick = _ref.onClick,
@@ -1327,14 +1327,15 @@ var Button = function Button(_ref) {
     className: dcnb('su-button su-group su-leading-display', levers.variant, levers.size, levers.disabled, className),
     onClick: onClick,
     type: type,
-    disabled: isDisabled
+    disabled: isDisabled,
+    ref: ref
   }, props), children, icon && /*#__PURE__*/React.createElement(Icon, _extends({
     icon: heroicon,
     type: "solid",
     "aria-hidden": true,
     className: dcnb('su-inline-block', levers.icon, levers.animate, iconClasses)
   }, iProps)));
-};
+});
 Button.propTypes = {
   type: propTypes.oneOf(buttonTypes),
   variant: propTypes.oneOf(buttonVariants),

--- a/dist/decanter-react.umd.js
+++ b/dist/decanter-react.umd.js
@@ -1260,7 +1260,7 @@
     return classes;
   };
 
-  var Button = function Button(_ref) {
+  var Button = /*#__PURE__*/React__default.forwardRef(function (_ref, ref) {
     var className = _ref.className,
         children = _ref.children,
         onClick = _ref.onClick,
@@ -1331,14 +1331,15 @@
       className: cnbuilder.dcnb('su-button su-group su-leading-display', levers.variant, levers.size, levers.disabled, className),
       onClick: onClick,
       type: type,
-      disabled: isDisabled
+      disabled: isDisabled,
+      ref: ref
     }, props), children, icon && /*#__PURE__*/React__default.createElement(Icon, _extends({
       icon: heroicon,
       type: "solid",
       "aria-hidden": true,
       className: cnbuilder.dcnb('su-inline-block', levers.icon, levers.animate, iconClasses)
     }, iProps)));
-  };
+  });
   Button.propTypes = {
     type: propTypes.oneOf(buttonTypes),
     variant: propTypes.oneOf(buttonVariants),

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -15,7 +15,7 @@ import { dcnb } from 'cnbuilder';
  *
  * HTML button element
  */
-export const Button = ({ className, children, onClick, variant, size, type, icon, iconProps, animate, isDisabled, ...props }) => {
+export const Button = React.forwardRef(({ className, children, onClick, variant, size, type, icon, iconProps, animate, isDisabled, ...props }, ref) => {
   // Defaults & Variables.
   // ---------------------------------------------------------------------------
   const levers = {};
@@ -78,6 +78,7 @@ export const Button = ({ className, children, onClick, variant, size, type, icon
       onClick={onClick}
       type={type}
       disabled={isDisabled}
+      ref={ref}
       {...props}
     >
       {children}
@@ -91,7 +92,7 @@ export const Button = ({ className, children, onClick, variant, size, type, icon
       }
     </button>
   );
-};
+});
 
 Button.propTypes = {
   /**

--- a/src/Button/Button.stories.js
+++ b/src/Button/Button.stories.js
@@ -153,9 +153,10 @@ export const ForwardRef = ({...args}) => {
       </div>
     </div>
   )
-}
+};
 
 ForwardRef.args = {
   children: 'Target Button',
   ref: buttonRef,
-}
+};
+ForwardRef.storyName = 'With Forwarded Ref';

--- a/src/Button/Button.stories.js
+++ b/src/Button/Button.stories.js
@@ -135,3 +135,27 @@ Richtext.args = {
   children: '🦸‍♀️ Be <span class="su-font-bold">BOLD</span> 🦸‍♂️',
 };
 Richtext.storyName = 'With Rich Text Content';
+
+const buttonRef = React.createRef();
+
+export const ForwardRef = ({...args}) => {
+  const setFocus = () => {
+    buttonRef.current.focus();
+  }
+
+  return (
+    <div>
+      <Button {...args} />
+      <div>
+      <a href="javascript:void(0);" onClick={setFocus}>
+        Clicking here will set focus using buttonRef.current.focus()
+      </a>
+      </div>
+    </div>
+  )
+}
+
+ForwardRef.args = {
+  children: 'Target Button',
+  ref: buttonRef,
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This adds support for passing refs to the button component, which facilitates setting focus states and other DOM manipulations.
- Also includes Storybook example to demonstrate how to work with refs. 
- This example can serve as a model for adding ref support to other components.

# Needed By (Date)
- Next 1-3 days.

# Urgency
- Low to Moderate

# Steps to Test
- Go to Simple => Button => With Forwarded Ref in Storybook to see an example of focus state being manipulated through a ref. 
- Also take a look at the code for the Story in Button.stories.js to get an idea of how this is utilized in code. 

# Affected Projects or Products
- This functionality could potentially be a breaking change for projects that depend on the Decanter library.
- See note in React documentation: https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/ADAPT-2140

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
