### PR TITLE
ADAPT-3101 Refactor CtaLink

### DIFF
--- a/src/CtaLink/CtaLink.js
+++ b/src/CtaLink/CtaLink.js
@@ -15,12 +15,29 @@ import { SrOnlyText } from "../SrOnlyText/SrOnlyText";
  */
 export const CtaLink = React.forwardRef(
   (
-    { className, text, srText, color, icon, iconProps, animate, ...props },
+    {
+      className,
+      children,
+      text,
+      srText,
+      color,
+      icon,
+      iconProps,
+      animate,
+      ...props
+    },
     ref
   ) => {
     // Defaults & Variables.
     // ---------------------------------------------------------------------------
     const levers = {};
+    let Element = "a";
+
+    // Determine whether a or div tag should be used based on children props
+    // ---------------------------------------------------------------------------
+    if (children) {
+      Element = "span";
+    }
 
     // Levers
     // ---------------------------------------------------------------------------
@@ -63,7 +80,7 @@ export const CtaLink = React.forwardRef(
     const { className: iconClasses, ...iProps } = iconProps || {};
 
     return (
-      <a
+      <Element
         className={dcnb(
           "su-cta-link su-text-19 md:su-text-20 su-block su-w-fit su-no-underline hover:su-underline focus:su-underline su-group su-transition-colors",
           levers.color,
@@ -74,7 +91,7 @@ export const CtaLink = React.forwardRef(
         ref={ref}
         {...props}
       >
-        {text}
+        {children || text}
         {srText && <SrOnlyText srText={` ${srText}`} />}
         {icon && (
           <Icon
@@ -90,7 +107,7 @@ export const CtaLink = React.forwardRef(
             {...iProps}
           />
         )}
-      </a>
+      </Element>
     );
   }
 );

--- a/src/CtaLink/CtaLink.stories.js
+++ b/src/CtaLink/CtaLink.stories.js
@@ -159,6 +159,24 @@ SrText.args = {
 };
 SrText.storyName = "Link with Screen Reader Only Text";
 
+const CtaLinkChildren = ({ ...rest }) => (
+  <CtaLink {...rest}>
+    <a
+      href="https://stanford.edu"
+      className="su-no-underline su-text-digital-red"
+    >
+      Passing in children props
+    </a>
+  </CtaLink>
+);
+
+export const CustomChildren = CtaLinkChildren.bind({});
+CustomChildren.args = {
+  animate: "right",
+  color: "red",
+};
+CustomChildren.storyName = "With Custom Children";
+
 const linkRef = React.createRef();
 
 export const ForwardRef = (args) => {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Refactor CtaLink to accept children props (i.e. <Sblink>)
08/12/21 — Note: Open another PR to test the idea of passing the icon down through the children props.

# Needed By (Date)
- tbd

# Urgency
- Low

# Steps to Test

1. Checkout this branch
2. Review locally `/?path=/story/simple-cta-link--custom-children` at or see Netlify preview
3. Check following:
- CtaLink should still works with `href` and `text` props.
- CtaLink should now accept children props (i.e. <a> tags, Gatsby <Link>, StoryBlok <SbLink>, etc).

# Associated Issues and/or People
- [ADAPT-3101](https://stanfordits.atlassian.net/browse/ADAPT-3101)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
