### PR TITLE
ADAPT-3128: Error Summary Box (and List) variation

### DIFF
--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Icon from 'react-hero-icon';
 import { dcnb } from 'cnbuilder';
-import { alertTypes, lightText, darkText } from './Alert.levers';
+import { alertTypes, lightText, darkText, redText } from './Alert.levers';
 import { DismissButton } from '../DismissButton/DismissButton';
 
 /**
@@ -96,6 +96,22 @@ export const Alert = ({ classes = {}, children, ...props }) => {
         defaultIcon = (
           <Icon
             icon="ban"
+            type="solid"
+            aria-hidden="true"
+            className={classes.icon}
+            {...iconProps}
+          />
+        );
+        break;
+
+      case 'errorSummary':
+        levers.wrapper =
+          'su-bg-digital-red su-bg-opacity-20 su-text-digital-red su-link-digital-red';
+        levers.body = redText;
+        levers.dismiss = 'red';
+        defaultIcon = (
+          <Icon
+            icon="exclamation-circle"
             type="solid"
             aria-hidden="true"
             className={classes.icon}

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -117,7 +117,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
 
       case 'errorSummary':
         levers.wrapper =
-          'su-bg-digital-red su-bg-opacity-20 su-text-digital-red su-link-digital-red';
+          'su-bg-digital-red su-bg-opacity-20 su-text-digital-red';
         levers.body = redText;
         levers.dismiss = 'red';
         levers.dismissIcon = 'x';

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -109,6 +109,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
           'su-bg-digital-red su-bg-opacity-20 su-text-digital-red su-link-digital-red';
         levers.body = redText;
         levers.dismiss = 'red';
+        levers.dismissIcon = 'x';
         defaultIcon = (
           <Icon
             icon="exclamation-circle"
@@ -131,6 +132,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
   const icon = props.icon ?? defaultIcon;
   const DefaultDismiss = (
     <DismissButton
+      icon={levers.dismissIcon || 'x-circle'}
       text="Dismiss"
       srText="alert"
       onClick={() => {

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -30,6 +30,9 @@ export const Alert = ({ classes = {}, children, ...props }) => {
   levers.wrapper = 'sm:su-items-center su-bg-foggy-light';
   levers.dismiss = 'black';
   levers.container = 'sm:su-items-center';
+  levers.dismissWrapper = 'su-mt-15 sm:su-mt-0 su-w-full sm:su-w-auto';
+  levers.headerWrapper = 'su-w-full md:su-w-max';
+  levers.bodyWrapper = 'su-w-full';
 
   // Is large Icon.
   if (props.isLargeIcon) {
@@ -156,7 +159,8 @@ export const Alert = ({ classes = {}, children, ...props }) => {
         break;
 
       default:
-      // none.
+        levers.container = dcnb(levers.container, 'sm:su-items-center');
+        break;
     }
   }
 
@@ -198,7 +202,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
         {props.hasDismiss && (
           <div
             className={dcnb(
-              'su-order-3 su-rs-ml-1 su-mt-15 sm:su-mt-0 su-flex-shrink su-text-right su-w-full sm:su-w-auto',
+              'su-order-3 su-rs-ml-1 su-flex-shrink su-text-right',
               levers.dismissWrapper,
               classes.dismissWrapper
             )}
@@ -212,7 +216,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
           (props.hasLabel && !props.isLabelTop)) && (
           <h2
             className={dcnb(
-              'su-order-1 su-rs-mr-1 su-mb-15 md:su-mb-0 su-flex su-flex-shrink su-w-full md:su-w-max',
+              'su-order-1 su-rs-mr-1 su-mb-15 md:su-mb-0 su-flex su-flex-shrink',
               levers.headerWrapper,
               classes.headerWrapper
             )}

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -121,6 +121,9 @@ export const Alert = ({ classes = {}, children, ...props }) => {
         levers.body = redText;
         levers.dismiss = 'red';
         levers.dismissIcon = 'x';
+        levers.container = 'su-flex-row su-flex-nowrap';
+        levers.dismissWrapper = 'su-w-auto su-mt-0';
+        levers.headerWrapper = 'su-w-auto su-mt-0';
         defaultIcon = (
           <Icon
             icon="exclamation-circle"
@@ -141,15 +144,15 @@ export const Alert = ({ classes = {}, children, ...props }) => {
   if (props.alignContent && alignment.includes(props.alignContent)) {
     switch (props.alignContent) {
       case 'top':
-        levers.container = 'sm:su-items-start';
+        levers.container = dcnb(levers.container, 'sm:su-items-start');
         break;
 
       case 'center':
-        levers.container = 'sm:su-items-center';
+        levers.container = dcnb(levers.container, 'sm:su-items-center');
         break;
 
       case 'bottom':
-        levers.container = 'sm:su-items-end';
+        levers.container = dcnb(levers.container, 'sm:su-items-end');
         break;
 
       default:

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -127,7 +127,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
         levers.dismissIcon = 'x';
         levers.container = 'su-flex-row su-flex-nowrap';
         levers.dismissWrapper = 'su-w-auto su-mt-0 su-rs-ml-0';
-        levers.headerWrapper = 'su-w-auto su-mt-0 su-rs-mr-neg2';
+        levers.headerWrapper = 'su-w-auto su-mt-0 su-mr-02em';
         defaultIcon = (
           <Icon
             icon="exclamation-circle"

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -127,7 +127,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
         levers.dismissIcon = 'x';
         levers.container = 'su-flex-row su-flex-nowrap';
         levers.dismissWrapper = 'su-w-auto su-mt-0 su-rs-ml-0';
-        levers.headerWrapper = 'su-w-auto su-mt-0 su-mr-02em';
+        levers.headerWrapper = 'su-w-auto su-mt-0 su-mr-01em';
         defaultIcon = (
           <Icon
             icon="exclamation-circle"

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -2,7 +2,13 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Icon from 'react-hero-icon';
 import { dcnb } from 'cnbuilder';
-import { alertTypes, lightText, darkText, redText } from './Alert.levers';
+import {
+  alertTypes,
+  alignment,
+  lightText,
+  darkText,
+  redText,
+} from './Alert.levers';
 import { DismissButton } from '../DismissButton/DismissButton';
 
 /**
@@ -21,8 +27,9 @@ export const Alert = ({ classes = {}, children, ...props }) => {
 
   // Levers
   // ---------------------------------------------------------------------------
-  levers.wrapper = 'su-bg-foggy-light';
+  levers.wrapper = 'sm:su-items-center su-bg-foggy-light';
   levers.dismiss = 'black';
+  levers.container = 'sm:su-items-center';
 
   // Is large Icon.
   if (props.isLargeIcon) {
@@ -48,6 +55,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
         levers.wrapper = 'su-bg-digital-green su-text-white';
         levers.body = lightText;
         levers.dismiss = 'white';
+        levers.dismissText = 'Dismiss';
         defaultIcon = (
           <Icon
             icon="check-circle"
@@ -63,6 +71,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
         levers.wrapper = 'su-bg-illuminating-dark';
         levers.body = darkText;
         levers.dismiss = 'black';
+        levers.dismissText = 'Dismiss';
         defaultIcon = (
           <Icon
             icon="exclamation-circle"
@@ -78,6 +87,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
         levers.wrapper = 'su-bg-digital-blue su-text-white';
         levers.body = lightText;
         levers.dismiss = 'white';
+        levers.dismissText = 'Dismiss';
         defaultIcon = (
           <Icon
             icon="information-circle"
@@ -93,6 +103,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
         levers.wrapper = 'su-bg-digital-red su-text-white';
         levers.body = lightText;
         levers.dismiss = 'white';
+        levers.dismissText = 'Dismiss';
         defaultIcon = (
           <Icon
             icon="ban"
@@ -126,6 +137,26 @@ export const Alert = ({ classes = {}, children, ...props }) => {
     }
   }
 
+  // Content Alignment
+  if (props.alignContent && alignment.includes(props.alignContent)) {
+    switch (props.alignContent) {
+      case 'top':
+        levers.container = 'sm:su-items-start';
+        break;
+
+      case 'center':
+        levers.container = 'sm:su-items-center';
+        break;
+
+      case 'bottom':
+        levers.container = 'sm:su-items-end';
+        break;
+
+      default:
+      // none.
+    }
+  }
+
   // Partials
   // ---------------------------------------------------------------------------
 
@@ -133,7 +164,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
   const DefaultDismiss = (
     <DismissButton
       icon={levers.dismissIcon || 'x-circle'}
-      text="Dismiss"
+      text={levers.dismissText}
       srText="alert"
       onClick={() => {
         setDismissed(true);
@@ -156,7 +187,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
     <div className={dcnb('su-alert', levers.wrapper, classes.wrapper)}>
       <div
         className={dcnb(
-          'su-cc su-flex su-flex-wrap su-rs-py-1 sm:su-items-center',
+          'su-cc su-flex su-flex-wrap su-rs-py-1',
           levers.container,
           classes.container
         )}
@@ -164,7 +195,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
         {props.hasDismiss && (
           <div
             className={dcnb(
-              'su-order-3 su-rs-ml-1 su-mt-15 sm:su-mt-0 su-items-center su-flex-shrink su-text-right su-w-full sm:su-w-auto',
+              'su-order-3 su-rs-ml-1 su-mt-15 sm:su-mt-0 su-flex-shrink su-text-right su-w-full sm:su-w-auto',
               levers.dismissWrapper,
               classes.dismissWrapper
             )}
@@ -178,7 +209,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
           (props.hasLabel && !props.isLabelTop)) && (
           <h2
             className={dcnb(
-              'su-order-1 su-rs-mr-1 su-mb-15 md:su-mb-0 su-flex su-flex-shrink su-items-center su-w-full md:su-w-max',
+              'su-order-1 su-rs-mr-1 su-mb-15 md:su-mb-0 su-flex su-flex-shrink su-w-full md:su-w-max',
               levers.headerWrapper,
               classes.headerWrapper
             )}
@@ -219,7 +250,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
         >
           {((props.hasIcon && props.isIconTop) ||
             (props.hasLabel && props.isLabelTop)) && (
-            <h2 className="su-flex su-items-center su-rs-mb-0">
+            <h2 className="su-flex su-rs-mb-0">
               {props.hasIcon && props.isIconTop && (
                 <span
                   className={dcnb(

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -1,15 +1,15 @@
-import React, { useState } from 'react';
-import PropTypes from 'prop-types';
-import Icon from 'react-hero-icon';
 import { dcnb } from 'cnbuilder';
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import Icon from 'react-hero-icon';
+import { DismissButton } from '../DismissButton/DismissButton';
 import {
   alertTypes,
   alignment,
-  lightText,
   darkText,
+  lightText,
   redText,
 } from './Alert.levers';
-import { DismissButton } from '../DismissButton/DismissButton';
 
 /**
  * Alert Component.
@@ -30,8 +30,9 @@ export const Alert = ({ classes = {}, children, ...props }) => {
   levers.wrapper = 'sm:su-items-center su-bg-foggy-light';
   levers.dismiss = 'black';
   levers.container = 'sm:su-items-center';
-  levers.dismissWrapper = 'su-mt-15 sm:su-mt-0 su-w-full sm:su-w-auto';
-  levers.headerWrapper = 'su-w-full md:su-w-max';
+  levers.dismissWrapper =
+    'su-rs-ml-1 su-mt-15 sm:su-mt-0 su-w-full sm:su-w-auto';
+  levers.headerWrapper = 'su-rs-mr-1 su-w-full md:su-w-max';
   levers.bodyWrapper = 'su-w-full';
 
   // Is large Icon.
@@ -125,8 +126,8 @@ export const Alert = ({ classes = {}, children, ...props }) => {
         levers.dismiss = 'red';
         levers.dismissIcon = 'x';
         levers.container = 'su-flex-row su-flex-nowrap';
-        levers.dismissWrapper = 'su-w-auto su-mt-0';
-        levers.headerWrapper = 'su-w-auto su-mt-0';
+        levers.dismissWrapper = 'su-w-auto su-mt-0 su-rs-ml-0';
+        levers.headerWrapper = 'su-w-auto su-mt-0 su-rs-mr-neg2';
         defaultIcon = (
           <Icon
             icon="exclamation-circle"
@@ -202,7 +203,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
         {props.hasDismiss && (
           <div
             className={dcnb(
-              'su-order-3 su-rs-ml-1 su-flex-shrink su-text-right',
+              'su-order-3 su-flex-shrink su-text-right',
               levers.dismissWrapper,
               classes.dismissWrapper
             )}
@@ -216,7 +217,7 @@ export const Alert = ({ classes = {}, children, ...props }) => {
           (props.hasLabel && !props.isLabelTop)) && (
           <h2
             className={dcnb(
-              'su-order-1 su-rs-mr-1 su-mb-15 md:su-mb-0 su-flex su-flex-shrink',
+              'su-order-1 su-mb-15 md:su-mb-0 su-flex su-flex-shrink',
               levers.headerWrapper,
               classes.headerWrapper
             )}

--- a/src/Alert/Alert.levers.js
+++ b/src/Alert/Alert.levers.js
@@ -17,13 +17,13 @@ export const alignment = ['top', 'center', 'bottom'];
 /**
  * Styles for light text
  */
-export const lightText = 'su-text-white su-link-white';
+export const lightText =
+  'su-text-white children:children:su-text-white children:children:hocus:!su-text-white';
 
 /**
  * Styles for dark text
  */
-export const darkText =
-  'su-text-black su-link-black-true hover:su-link-no-underline';
+export const darkText = 'su-text-black';
 
 /**
  * Styles for red text

--- a/src/Alert/Alert.levers.js
+++ b/src/Alert/Alert.levers.js
@@ -1,7 +1,13 @@
 /**
  * Default Types for the type prop.
  */
-export const alertTypes = ['info', 'warning', 'error', 'success'];
+export const alertTypes = [
+  'info',
+  'warning',
+  'error',
+  'success',
+  'errorSummary',
+];
 
 /**
  * Styles for light text
@@ -11,4 +17,11 @@ export const lightText = 'su-text-white su-link-white';
 /**
  * Styles for dark text
  */
-export const darkText = 'su-text-black su-link-black-true';
+export const darkText =
+  'su-text-black su-link-black-true hover:su-link-no-underline';
+
+/**
+ * Styles for red text
+ */
+export const redText =
+  'su-text-digital-red su-link-digital-blue hover:su-link-no-underline';

--- a/src/Alert/Alert.levers.js
+++ b/src/Alert/Alert.levers.js
@@ -18,7 +18,7 @@ export const alignment = ['top', 'center', 'bottom'];
  * Styles for light text
  */
 export const lightText =
-  'su-text-white children:children:su-text-white children:children:hocus:!su-text-white';
+  'su-text-white children:children:!su-text-white children:children:hocus:!su-text-white';
 
 /**
  * Styles for dark text

--- a/src/Alert/Alert.levers.js
+++ b/src/Alert/Alert.levers.js
@@ -10,6 +10,11 @@ export const alertTypes = [
 ];
 
 /**
+ * Alignment options for icon, text, and dismiss.
+ */
+export const alignment = ['top', 'center', 'bottom'];
+
+/**
  * Styles for light text
  */
 export const lightText = 'su-text-white su-link-white';

--- a/src/Alert/Alert.levers.js
+++ b/src/Alert/Alert.levers.js
@@ -28,5 +28,4 @@ export const darkText =
 /**
  * Styles for red text
  */
-export const redText =
-  'su-text-digital-red su-link-digital-blue hover:su-link-no-underline';
+export const redText = 'su-text-digital-red';

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -192,7 +192,8 @@ ErrorSummaryBox.args = {
   type: 'errorSummary',
   label: '',
   classes: {
-    container: 'su-items-start',
+    wrapper: 'su-w-full su-max-w-700',
+    container: 'su-px-18 su-pt-18 su-pb-26',
   },
 };
 ErrorSummaryBox.parameters = {
@@ -209,7 +210,8 @@ ErrorSummaryListBox.args = {
   type: 'errorSummary',
   label: '',
   classes: {
-    container: 'su-items-start',
+    wrapper: 'su-w-full su-max-w-700',
+    container: 'su-px-18 su-pt-18 su-pb-26',
   },
 };
 ErrorSummaryListBox.parameters = {

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -59,7 +59,7 @@ const errorListBody = (
           Field name one
         </a>
       </li>
-      <li className="su-mb-12">
+      <li className="su-leading-display">
         <a href="/" className="su-underline hocus:su-no-underline">
           Field name two
         </a>

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { withDesign } from 'storybook-addon-designs';
-import { Alert } from './Alert';
 import { DismissButton } from '../DismissButton/DismissButton';
+import { Alert } from './Alert';
 import { alertTypes, alignment } from './Alert.levers';
 
 const alertBody = (
@@ -211,7 +211,7 @@ ErrorSummaryBox.args = {
   label: '',
   alignContent: 'top',
   classes: {
-    wrapper: 'su-w-full su-max-w-700',
+    wrapper: 'su-w-full su-max-w-[56rem]',
     container: 'su-rs-px-0 su-rs-pt-0 su-rs-pb-1',
   },
 };
@@ -231,7 +231,7 @@ ErrorSummaryListBox.args = {
   label: '',
   alignContent: 'top',
   classes: {
-    wrapper: 'su-w-full su-max-w-700',
+    wrapper: 'su-w-full su-max-w-[56rem]',
     container: 'su-rs-px-0 su-rs-pt-0 su-rs-pb-1',
   },
 };

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -44,7 +44,7 @@ const errorListBody = (
       information.
     </p>
     <ul className="su-list-none su-pl-0">
-      <li className="su-mb-12">
+      <li className="su-leading-display su-mb-08em">
         <a href="/" className="su-underline hocus:su-no-underline">
           Address line 1
         </a>

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -36,7 +36,7 @@ const errorBody = (
 
 const errorListBody = (
   <div className="last:su-mb-0 su-leading-display su-card-paragraph su-text-18">
-    <p className="su-mb-6">
+    <p className="su-mb-02em su-leading-display">
       <strong>Please revise inputs to the following fields.</strong>
     </p>
     <p className="su-rs-mb-0 su-leading-display">

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -54,7 +54,7 @@ const errorListBody = (
           Expiration date
         </a>
       </li>
-      <li className="su-mb-12">
+      <li className="su-leading-display su-mb-08em">
         <a href="/" className="su-underline hocus:su-no-underline">
           Field name one
         </a>

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -26,7 +26,11 @@ const errorBody = (
     <strong>Account locked for your security</strong>
     <br />
     You attempted to log in too many times. Please try again in 24 hours or
-    contact <a href="/">Customer Service</a> M-F 8am-5pm Pacific.
+    contact{' '}
+    <a href="/" className="su-underline hocus:su-no-underline">
+      Customer Service
+    </a>{' '}
+    M-F 8am-5pm Pacific.
   </p>
 );
 
@@ -41,16 +45,24 @@ const errorListBody = (
     </p>
     <ul className="su-list-none su-pl-0">
       <li className="su-mb-12">
-        <a href="/">Address line 1</a>
+        <a href="/" className="su-underline hocus:su-no-underline">
+          Address line 1
+        </a>
       </li>
       <li className="su-mb-12">
-        <a href="/">Expiration date</a>
+        <a href="/" className="su-underline hocus:su-no-underline">
+          Expiration date
+        </a>
       </li>
       <li className="su-mb-12">
-        <a href="/">Field name one</a>
+        <a href="/" className="su-underline hocus:su-no-underline">
+          Field name one
+        </a>
       </li>
       <li className="su-mb-12">
-        <a href="/">Field name two</a>
+        <a href="/" className="su-underline hocus:su-no-underline">
+          Field name two
+        </a>
       </li>
     </ul>
   </div>

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -39,7 +39,7 @@ const errorListBody = (
     <p className="su-mb-6">
       <strong>Please revise inputs to the following fields.</strong>
     </p>
-    <p className="su-mb-18">
+    <p className="su-rs-mb-0 su-leading-display">
       Some of your inputs need revising. Please see each field for more
       information.
     </p>

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -21,6 +21,41 @@ const alertBodyShort = (
   </p>
 );
 
+const errorBody = (
+  <p className="last:su-mb-0 su-leading-display su-card-paragraph su-text-18">
+    <strong>Account locked for your security</strong>
+    <br />
+    You attempted to log in too many times. Please try again in 24 hours or
+    contact <a href="/">Customer Service</a> M-F 8am-5pm Pacific.
+  </p>
+);
+
+const errorListBody = (
+  <div className="last:su-mb-0 su-leading-display su-card-paragraph su-text-18">
+    <p className="su-mb-6">
+      <strong>Please revise inputs to the following fields.</strong>
+    </p>
+    <p className="su-mb-18">
+      Some of your inputs need revising. Please see each field for more
+      information.
+    </p>
+    <ul className="su-list-none su-pl-0">
+      <li className="su-mb-12">
+        <a href="/">Address line 1</a>
+      </li>
+      <li className="su-mb-12">
+        <a href="/">Expiration date</a>
+      </li>
+      <li className="su-mb-12">
+        <a href="/">Field name one</a>
+      </li>
+      <li className="su-mb-12">
+        <a href="/">Field name two</a>
+      </li>
+    </ul>
+  </div>
+);
+
 export default {
   title: 'Composite/Alert',
   decorators: [withDesign],
@@ -150,3 +185,37 @@ NoDismiss.args = {
   hasDismiss: false,
 };
 NoDismiss.storyName = 'No Dismiss Button';
+
+export const ErrorSummaryBox = AlertTemplate.bind({});
+ErrorSummaryBox.args = {
+  children: errorBody,
+  type: 'errorSummary',
+  label: '',
+  classes: {
+    container: 'su-items-start',
+  },
+};
+ErrorSummaryBox.parameters = {
+  docs: {
+    description: {
+      story: 'Error Summary Box.',
+    },
+  },
+};
+
+export const ErrorSummaryListBox = AlertTemplate.bind({});
+ErrorSummaryListBox.args = {
+  children: errorListBody,
+  type: 'errorSummary',
+  label: '',
+  classes: {
+    container: 'su-items-start',
+  },
+};
+ErrorSummaryListBox.parameters = {
+  docs: {
+    description: {
+      story: 'Error Summary List Box.',
+    },
+  },
+};

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { withDesign } from 'storybook-addon-designs';
 import { Alert } from './Alert';
 import { DismissButton } from '../DismissButton/DismissButton';
-import { alertTypes } from './Alert.levers';
+import { alertTypes, alignment } from './Alert.levers';
 
 const alertBody = (
   <p className="last:su-mb-0 su-leading-display su-card-paragraph">
@@ -78,6 +78,12 @@ export default {
       control: {
         type: 'select',
         options: alertTypes,
+      },
+    },
+    alignContent: {
+      control: {
+        type: 'select',
+        options: alignment,
       },
     },
   },
@@ -191,6 +197,7 @@ ErrorSummaryBox.args = {
   children: errorBody,
   type: 'errorSummary',
   label: '',
+  alignContent: 'top',
   classes: {
     wrapper: 'su-w-full su-max-w-700',
     container: 'su-px-18 su-pt-18 su-pb-26',
@@ -199,16 +206,18 @@ ErrorSummaryBox.args = {
 ErrorSummaryBox.parameters = {
   docs: {
     description: {
-      story: 'Error Summary Box.',
+      story: 'Form Error Summary Box',
     },
   },
 };
+ErrorSummaryBox.storyName = 'Form Error Summary';
 
 export const ErrorSummaryListBox = AlertTemplate.bind({});
 ErrorSummaryListBox.args = {
   children: errorListBody,
   type: 'errorSummary',
   label: '',
+  alignContent: 'top',
   classes: {
     wrapper: 'su-w-full su-max-w-700',
     container: 'su-px-18 su-pt-18 su-pb-26',
@@ -217,7 +226,8 @@ ErrorSummaryListBox.args = {
 ErrorSummaryListBox.parameters = {
   docs: {
     description: {
-      story: 'Error Summary List Box.',
+      story: 'Form Error Summary List Box',
     },
   },
 };
+ErrorSummaryListBox.storyName = 'Form Error List';

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -212,7 +212,7 @@ ErrorSummaryBox.args = {
   alignContent: 'top',
   classes: {
     wrapper: 'su-w-full su-max-w-700',
-    container: 'su-px-18 su-pt-18 su-pb-26',
+    container: 'su-rs-px-0 su-rs-pt-0 su-rs-pb-1',
   },
 };
 ErrorSummaryBox.parameters = {

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -232,7 +232,7 @@ ErrorSummaryListBox.args = {
   alignContent: 'top',
   classes: {
     wrapper: 'su-w-full su-max-w-700',
-    container: 'su-px-18 su-pt-18 su-pb-26',
+    container: 'su-rs-px-0 su-rs-pt-0 su-rs-pb-1',
   },
 };
 ErrorSummaryListBox.parameters = {

--- a/src/Alert/Alert.stories.js
+++ b/src/Alert/Alert.stories.js
@@ -49,7 +49,7 @@ const errorListBody = (
           Address line 1
         </a>
       </li>
-      <li className="su-mb-12">
+      <li className="su-leading-display su-mb-08em">
         <a href="/" className="su-underline hocus:su-no-underline">
           Expiration date
         </a>

--- a/src/DismissButton/DismissButton.js
+++ b/src/DismissButton/DismissButton.js
@@ -47,8 +47,8 @@ export const DismissButton = ({
         levers.color = 'su-text-white hocus:su-text-white';
         break;
 
-      case "red":
-        levers.color = "su-text-digital-red hocus:su-text-digital-red";
+      case 'red':
+        levers.color = 'su-text-digital-red hocus:su-text-digital-red';
         break;
 
       default:

--- a/src/DismissButton/DismissButton.js
+++ b/src/DismissButton/DismissButton.js
@@ -47,6 +47,10 @@ export const DismissButton = ({
         levers.color = 'su-text-white hocus:su-text-white';
         break;
 
+      case "red":
+        levers.color = "su-text-digital-red hocus:su-text-digital-red";
+        break;
+
       default:
       // none.
     }

--- a/src/DismissButton/DismissButton.levers.js
+++ b/src/DismissButton/DismissButton.levers.js
@@ -1,7 +1,7 @@
 /**
  * Text and icon color for the dismiss button
  */
-export const dismissIconColors = ['black', 'white', 'unset'];
+export const dismissIconColors = ['black', 'white', 'red', 'unset'];
 
 /**
  * Heroicon options for the Dismiss Button


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add Error Summary Box variation that works with a lists of links.

# Needed By (Date)
- tbd

# Urgency
- medium/low

# Steps to Test

1. Pull this PR
2. Review locally at `/story/composite-alert--error-summary-box` or [Netlify Preview](https://deploy-preview-70--decanter-react.netlify.app/?path=/story/composite-alert--error-summary-box)
3. Compare to [Figma mocks](https://www.figma.com/file/Kmd4utmJFPRMVeCFEEBQhLtx/Decanter-Design-System?node-id=12672%3A2604)
**Note:** With the current structure of alerts, the Icon and Dismiss Btn are centered align regardless of whether a different alignment is passed in as a class/style prop.

# Affected Projects or Products
- DERF

# Associated Issues and/or People
- [ADAPT-3128](https://stanfordits.atlassian.net/browse/ADAPT-3128)
- [ADAPT-3129](https://stanfordits.atlassian.net/browse/ADAPT-3129)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
