### PR TITLE
ADAPT-3828 Adjust HeroIcon types

### DIFF
--- a/src/HeroIcon/HeroIcon.js
+++ b/src/HeroIcon/HeroIcon.js
@@ -1,16 +1,16 @@
 /* eslint-disable import/no-unresolved */
 import {
+  ChevronRightIcon,
   InformationCircleIcon,
+  MailIcon,
   MicrophoneIcon,
   VideoCameraIcon,
 } from '@heroicons/react/outline';
 import {
   ArrowRightIcon,
   ChevronDownIcon,
-  ChevronRightIcon,
   DownloadIcon,
   LockClosedIcon,
-  MailIcon,
   PlayIcon,
 } from '@heroicons/react/solid';
 import { dcnb } from 'cnbuilder';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adjust HeroIcon types from solid to outline for Chevron Right and Email. 

# Needed By (Date)
- asap

# Urgency
- medium

# Steps to Test

1. Pull this branch and review locally at `/story/simple-hero-icon--action` and `/story/simple-hero-icon--email` and `/story/simple-hero-icon--jump`
2. Or on Netlify Previews
- Chevron Right: https://deploy-preview-80--decanter-react.netlify.app/?path=/story/simple-hero-icon--action
- Email: https://deploy-preview-80--decanter-react.netlify.app/?path=/story/simple-hero-icon--email
- Jump (should display Jump icon, not Email icon): https://deploy-preview-80--decanter-react.netlify.app/?path=/story/simple-hero-icon--jump

# Affected Projects or Products
- DERF

# Associated Issues and/or People
- [ADAPT-3828](https://stanfordits.atlassian.net/browse/ADAPT-3828)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
