### PR TITLE
ADAPT-3762 Add icon button alignment options

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -125,7 +125,8 @@ export const Button = React.forwardRef(
         ref={ref}
         {...props}
       >
-        {icon && iconPosition === 'left' ? (
+        {iconPosition === 'right' ? <>{children}</> : null}
+        {icon && (
           <HeroIcon
             icon={heroicon}
             aria-hidden
@@ -137,21 +138,8 @@ export const Button = React.forwardRef(
             )}
             {...iProps}
           />
-        ) : null}
-        {children}
-        {icon && iconPosition === 'right' ? (
-          <HeroIcon
-            icon={heroicon}
-            aria-hidden
-            className={dcnb(
-              'su-inline-block',
-              levers.animate,
-              levers.iconPositionStyles,
-              iconClasses
-            )}
-            {...iProps}
-          />
-        ) : null}
+        )}
+        {iconPosition === 'left' ? <>{children}</> : null}
       </button>
     );
   }

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -125,7 +125,7 @@ export const Button = React.forwardRef(
         ref={ref}
         {...props}
       >
-        {iconPosition === 'right' ? <>{children}</> : null}
+        {iconPosition === 'right' && children}
         {icon && (
           <HeroIcon
             icon={heroicon}
@@ -139,7 +139,7 @@ export const Button = React.forwardRef(
             {...iProps}
           />
         )}
-        {iconPosition === 'left' ? <>{children}</> : null}
+        {iconPosition === 'left' && children}
       </button>
     );
   }

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -6,9 +6,13 @@ import getButtonSize from '../common/button/getButtonSize';
 import getIconAnimation from '../common/icon/getIconAnimation';
 import getIconClasses from '../common/icon/getIconClasses';
 import getIconPosition from '../common/icon/getIconPosition';
-import { iconAnimations, iconOptions } from '../common/icon/icon.levers';
+import {
+  iconAlignment,
+  iconAnimations,
+  iconOptions,
+} from '../common/icon/icon.levers';
 import { HeroIcon } from '../HeroIcon/HeroIcon';
-import { buttonTypes, buttonVariants, iconAlignment } from './Button.levers';
+import { buttonTypes, buttonVariants } from './Button.levers';
 
 /**
  * Button Component

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -5,6 +5,7 @@ import { buttonSizes } from '../common/button/button.levers';
 import getButtonSize from '../common/button/getButtonSize';
 import getIconAnimation from '../common/icon/getIconAnimation';
 import getIconClasses from '../common/icon/getIconClasses';
+import getIconPosition from '../common/icon/getIconPosition';
 import { iconAnimations, iconOptions } from '../common/icon/icon.levers';
 import { HeroIcon } from '../HeroIcon/HeroIcon';
 import { buttonTypes, buttonVariants, iconAlignment } from './Button.levers';
@@ -38,10 +39,6 @@ export const Button = React.forwardRef(
 
     // Levers
     // ---------------------------------------------------------------------------
-
-    if (iconPosition === 'left') {
-      levers.iconLeadingStyles = '!su-ml-0 su-mr-7';
-    }
 
     // variant
     if (variant && buttonVariants.includes(variant)) {
@@ -82,6 +79,7 @@ export const Button = React.forwardRef(
     if (icon && iconOptions.includes(icon)) {
       heroicon = icon;
       levers.icon = getIconClasses(icon);
+      levers.iconPositionStyles = getIconPosition(icon, iconPosition);
     }
 
     // animate
@@ -130,7 +128,7 @@ export const Button = React.forwardRef(
             className={dcnb(
               'su-inline-block',
               levers.animate,
-              levers.iconLeadingStyles,
+              levers.iconPositionStyles,
               iconClasses
             )}
             {...iProps}
@@ -141,7 +139,12 @@ export const Button = React.forwardRef(
           <HeroIcon
             icon={heroicon}
             aria-hidden
-            className={dcnb('su-inline-block', levers.animate, iconClasses)}
+            className={dcnb(
+              'su-inline-block',
+              levers.animate,
+              levers.iconPositionStyles,
+              iconClasses
+            )}
             {...iProps}
           />
         ) : null}

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -7,7 +7,7 @@ import getIconAnimation from '../common/icon/getIconAnimation';
 import getIconClasses from '../common/icon/getIconClasses';
 import { iconAnimations, iconOptions } from '../common/icon/icon.levers';
 import { HeroIcon } from '../HeroIcon/HeroIcon';
-import { buttonTypes, buttonVariants } from './Button.levers';
+import { buttonTypes, buttonVariants, iconAlignment } from './Button.levers';
 
 /**
  * Button Component
@@ -25,6 +25,7 @@ export const Button = React.forwardRef(
       type,
       icon,
       iconProps,
+      iconPosition,
       animate,
       isDisabled,
       ...props
@@ -37,6 +38,10 @@ export const Button = React.forwardRef(
 
     // Levers
     // ---------------------------------------------------------------------------
+
+    if (iconPosition === 'left') {
+      levers.iconLeadingStyles = '!su-ml-0 su-mr-7';
+    }
 
     // variant
     if (variant && buttonVariants.includes(variant)) {
@@ -118,15 +123,28 @@ export const Button = React.forwardRef(
         ref={ref}
         {...props}
       >
+        {icon && iconPosition === 'left' ? (
+          <HeroIcon
+            icon={heroicon}
+            aria-hidden
+            className={dcnb(
+              'su-inline-block',
+              levers.animate,
+              levers.iconLeadingStyles,
+              iconClasses
+            )}
+            {...iProps}
+          />
+        ) : null}
         {children}
-        {icon && (
+        {icon && iconPosition === 'right' ? (
           <HeroIcon
             icon={heroicon}
             aria-hidden
             className={dcnb('su-inline-block', levers.animate, iconClasses)}
             {...iProps}
           />
-        )}
+        ) : null}
       </button>
     );
   }
@@ -157,6 +175,11 @@ Button.propTypes = {
    * Icon Properties
    */
   iconProps: PropTypes.objectOf(PropTypes.any),
+
+  /**
+   * Icon Position options
+   */
+  iconPosition: PropTypes.oneOf(iconAlignment),
 
   /**
    * Icon animation on hover/focus
@@ -200,4 +223,5 @@ Button.defaultProps = {
   variant: 'solid',
   size: 'default',
   isDisabled: false,
+  iconPosition: 'right',
 };

--- a/src/Button/Button.levers.js
+++ b/src/Button/Button.levers.js
@@ -9,3 +9,8 @@ export const buttonVariants = ['solid', 'outline', 'ghost', 'unset'];
  * Type of the button HTML element
  */
 export const buttonTypes = ['button', 'submit', 'reset'];
+
+/**
+ * Button icon alignment
+ */
+export const iconAlignment = ['left', 'right'];

--- a/src/Button/Button.levers.js
+++ b/src/Button/Button.levers.js
@@ -9,8 +9,3 @@ export const buttonVariants = ['solid', 'outline', 'ghost', 'unset'];
  * Type of the button HTML element
  */
 export const buttonTypes = ['button', 'submit', 'reset'];
-
-/**
- * Button icon alignment
- */
-export const iconAlignment = ['left', 'right'];

--- a/src/Button/Button.stories.js
+++ b/src/Button/Button.stories.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { buttonSizes } from '../common/button/button.levers';
 import { iconAnimations, iconOptions } from '../common/icon/icon.levers';
 import { Button } from './Button';
-import { buttonTypes, buttonVariants } from './Button.levers';
+import { buttonTypes, buttonVariants, iconAlignment } from './Button.levers';
 
 export default {
   title: 'Simple/Button',
@@ -46,6 +46,12 @@ export default {
     },
     onClick: {
       action: 'clicked',
+    },
+    iconPosition: {
+      control: {
+        type: 'select',
+        options: iconAlignment,
+      },
     },
   },
 };
@@ -119,6 +125,15 @@ Download.args = {
   children: 'Download Button',
 };
 Download.storyName = 'With Download Icon';
+
+export const Email = ButtonTemplate.bind({});
+Email.args = {
+  variant: 'solid',
+  icon: 'email',
+  children: 'Email Button',
+  iconPosition: 'left',
+};
+Email.storyName = 'With Leading Email Icon';
 
 export const Disabled = ButtonTemplate.bind({});
 Disabled.args = {

--- a/src/Button/Button.stories.js
+++ b/src/Button/Button.stories.js
@@ -1,9 +1,13 @@
 import DOMPurify from 'dompurify';
 import React from 'react';
 import { buttonSizes } from '../common/button/button.levers';
-import { iconAnimations, iconOptions } from '../common/icon/icon.levers';
+import {
+  iconAlignment,
+  iconAnimations,
+  iconOptions,
+} from '../common/icon/icon.levers';
 import { Button } from './Button';
-import { buttonTypes, buttonVariants, iconAlignment } from './Button.levers';
+import { buttonTypes, buttonVariants } from './Button.levers';
 
 export default {
   title: 'Simple/Button',

--- a/src/Button/Button.stories.js
+++ b/src/Button/Button.stories.js
@@ -130,6 +130,16 @@ Download.args = {
 };
 Download.storyName = 'With Download Icon';
 
+export const Upload = ButtonTemplate.bind({});
+Upload.args = {
+  variant: 'solid',
+  icon: 'upload',
+  animate: 'up',
+  children: 'Upload Button',
+  iconPosition: 'right',
+};
+Upload.storyName = 'With Upload Icon';
+
 export const Email = ButtonTemplate.bind({});
 Email.args = {
   variant: 'solid',

--- a/src/Button/Button.stories.js
+++ b/src/Button/Button.stories.js
@@ -53,7 +53,7 @@ export default {
     },
     iconPosition: {
       control: {
-        type: 'select',
+        type: 'inline-radio',
         options: iconAlignment,
       },
     },

--- a/src/CtaButton/CtaButton.js
+++ b/src/CtaButton/CtaButton.js
@@ -1,13 +1,16 @@
 import { dcnb } from 'cnbuilder';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { iconAlignment } from '../Button/Button.levers';
 import { buttonSizes } from '../common/button/button.levers';
 import getButtonSize from '../common/button/getButtonSize';
 import getIconAnimation from '../common/icon/getIconAnimation';
 import getIconClasses from '../common/icon/getIconClasses';
 import getIconPosition from '../common/icon/getIconPosition';
-import { iconAnimations, iconOptions } from '../common/icon/icon.levers';
+import {
+  iconAlignment,
+  iconAnimations,
+  iconOptions,
+} from '../common/icon/icon.levers';
 import { HeroIcon } from '../HeroIcon/HeroIcon';
 import { SrOnlyText } from '../SrOnlyText/SrOnlyText';
 import { ctaButtonVariants } from './CtaButton.levers';

--- a/src/CtaButton/CtaButton.js
+++ b/src/CtaButton/CtaButton.js
@@ -99,12 +99,12 @@ export const CtaButton = React.forwardRef(
         ref={ref}
         {...props}
       >
-        {iconPosition === 'right' ? (
+        {iconPosition === 'right' && (
           <>
             {text}
             {srText && <SrOnlyText srText={` ${srText}`} />}
           </>
-        ) : null}
+        )}
         {icon && (
           <HeroIcon
             icon={heroicon}
@@ -118,12 +118,12 @@ export const CtaButton = React.forwardRef(
             {...iProps}
           />
         )}
-        {iconPosition === 'left' ? (
+        {iconPosition === 'left' && (
           <>
             {text}
             {srText && <SrOnlyText srText={` ${srText}`} />}
           </>
-        ) : null}
+        )}
       </a>
     );
   }

--- a/src/CtaButton/CtaButton.js
+++ b/src/CtaButton/CtaButton.js
@@ -1,10 +1,12 @@
 import { dcnb } from 'cnbuilder';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { iconAlignment } from '../Button/Button.levers';
 import { buttonSizes } from '../common/button/button.levers';
 import getButtonSize from '../common/button/getButtonSize';
 import getIconAnimation from '../common/icon/getIconAnimation';
 import getIconClasses from '../common/icon/getIconClasses';
+import getIconPosition from '../common/icon/getIconPosition';
 import { iconAnimations, iconOptions } from '../common/icon/icon.levers';
 import { HeroIcon } from '../HeroIcon/HeroIcon';
 import { SrOnlyText } from '../SrOnlyText/SrOnlyText';
@@ -24,6 +26,7 @@ export const CtaButton = React.forwardRef(
       size,
       icon,
       iconProps,
+      iconPosition,
       animate,
       ...props
     },
@@ -70,6 +73,7 @@ export const CtaButton = React.forwardRef(
     if (icon && iconOptions.includes(icon)) {
       heroicon = icon;
       levers.icon = getIconClasses(icon);
+      levers.iconPositionStyles = getIconPosition(icon, iconPosition);
     }
 
     // animate
@@ -92,9 +96,22 @@ export const CtaButton = React.forwardRef(
         ref={ref}
         {...props}
       >
+        {icon && iconPosition === 'left' ? (
+          <HeroIcon
+            icon={heroicon}
+            aria-hidden
+            className={dcnb(
+              'su-inline-block',
+              levers.animate,
+              levers.iconPositionStyles,
+              iconClasses
+            )}
+            {...iProps}
+          />
+        ) : null}
         {text}
         {srText && <SrOnlyText srText={` ${srText}`} />}
-        {icon && (
+        {icon && iconPosition === 'right' ? (
           <HeroIcon
             icon={heroicon}
             type="solid"
@@ -103,11 +120,12 @@ export const CtaButton = React.forwardRef(
               'su-inline-block',
               levers.icon,
               levers.animate,
+              levers.iconPositionStyles,
               iconClasses
             )}
             {...iProps}
           />
-        )}
+        ) : null}
       </a>
     );
   }
@@ -135,9 +153,14 @@ CtaButton.propTypes = {
   icon: PropTypes.oneOf(iconOptions),
 
   /**
-   * Icon options
+   * Icon Properties
    */
   iconProps: PropTypes.objectOf(PropTypes.any),
+
+  /**
+   * Icon Position options
+   */
+  iconPosition: PropTypes.oneOf(iconAlignment),
 
   /**
    * Icon animation on hover/focus
@@ -168,4 +191,5 @@ CtaButton.propTypes = {
 // -----------------------------------------------------------------------------
 CtaButton.defaultProps = {
   variant: 'solid',
+  iconPosition: 'right',
 };

--- a/src/CtaButton/CtaButton.js
+++ b/src/CtaButton/CtaButton.js
@@ -99,35 +99,30 @@ export const CtaButton = React.forwardRef(
         ref={ref}
         {...props}
       >
-        {icon && iconPosition === 'left' ? (
-          <HeroIcon
-            icon={heroicon}
-            aria-hidden
-            className={dcnb(
-              'su-inline-block',
-              levers.animate,
-              levers.iconPositionStyles,
-              iconClasses
-            )}
-            {...iProps}
-          />
+        {iconPosition === 'right' ? (
+          <>
+            {text}
+            {srText && <SrOnlyText srText={` ${srText}`} />}
+          </>
         ) : null}
-        {text}
-        {srText && <SrOnlyText srText={` ${srText}`} />}
-        {icon && iconPosition === 'right' ? (
+        {icon && (
           <HeroIcon
             icon={heroicon}
-            type="solid"
             aria-hidden
             className={dcnb(
               'su-inline-block',
-              levers.icon,
               levers.animate,
               levers.iconPositionStyles,
               iconClasses
             )}
             {...iProps}
           />
+        )}
+        {iconPosition === 'left' ? (
+          <>
+            {text}
+            {srText && <SrOnlyText srText={` ${srText}`} />}
+          </>
         ) : null}
       </a>
     );

--- a/src/CtaButton/CtaButton.stories.js
+++ b/src/CtaButton/CtaButton.stories.js
@@ -1,9 +1,13 @@
 import React from 'react';
-import { CtaButton } from './CtaButton';
-import { SrOnlyText } from '../SrOnlyText/SrOnlyText';
-import { ctaButtonVariants } from './CtaButton.levers';
 import { buttonSizes } from '../common/button/button.levers';
-import { iconOptions, iconAnimations } from '../common/icon/icon.levers';
+import {
+  iconAlignment,
+  iconAnimations,
+  iconOptions,
+} from '../common/icon/icon.levers';
+import { SrOnlyText } from '../SrOnlyText/SrOnlyText';
+import { CtaButton } from './CtaButton';
+import { ctaButtonVariants } from './CtaButton.levers';
 
 export default {
   title: 'Simple/CTA Link Button',
@@ -32,6 +36,12 @@ export default {
       control: {
         type: 'inline-radio',
         options: iconAnimations,
+      },
+    },
+    iconPosition: {
+      control: {
+        type: 'select',
+        options: iconAlignment,
       },
     },
   },

--- a/src/CtaButton/CtaButton.stories.js
+++ b/src/CtaButton/CtaButton.stories.js
@@ -40,7 +40,7 @@ export default {
     },
     iconPosition: {
       control: {
-        type: 'select',
+        type: 'inline-radio',
         options: iconAlignment,
       },
     },

--- a/src/CtaLink/CtaLink.js
+++ b/src/CtaLink/CtaLink.js
@@ -89,12 +89,12 @@ export const CtaLink = React.forwardRef(
         ref={ref}
         {...props}
       >
-        {iconPosition === 'right' ? (
+        {iconPosition === 'right' && (
           <>
             {text}
             {srText && <SrOnlyText srText={` ${srText}`} />}
           </>
-        ) : null}
+        )}
         {icon && (
           <HeroIcon
             icon={heroicon}
@@ -108,12 +108,12 @@ export const CtaLink = React.forwardRef(
             {...iProps}
           />
         )}
-        {iconPosition === 'left' ? (
+        {iconPosition === 'left' && (
           <>
             {text}
             {srText && <SrOnlyText srText={` ${srText}`} />}
           </>
-        ) : null}
+        )}
       </a>
     );
   }

--- a/src/CtaLink/CtaLink.js
+++ b/src/CtaLink/CtaLink.js
@@ -1,11 +1,14 @@
 import { dcnb } from 'cnbuilder';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { iconAlignment } from '../Button/Button.levers';
 import getIconAnimation from '../common/icon/getIconAnimation';
 import getIconClasses from '../common/icon/getIconClasses';
 import getIconPosition from '../common/icon/getIconPosition';
-import { iconAnimations, iconOptions } from '../common/icon/icon.levers';
+import {
+  iconAlignment,
+  iconAnimations,
+  iconOptions,
+} from '../common/icon/icon.levers';
 import { HeroIcon } from '../HeroIcon/HeroIcon';
 import { SrOnlyText } from '../SrOnlyText/SrOnlyText';
 import { ctaLinkColors } from './CtaLink.levers';

--- a/src/CtaLink/CtaLink.js
+++ b/src/CtaLink/CtaLink.js
@@ -89,35 +89,30 @@ export const CtaLink = React.forwardRef(
         ref={ref}
         {...props}
       >
-        {icon && iconPosition === 'left' ? (
-          <HeroIcon
-            icon={heroicon}
-            aria-hidden
-            className={dcnb(
-              'su-inline-block',
-              levers.animate,
-              levers.iconPositionStyles,
-              iconClasses
-            )}
-            {...iProps}
-          />
+        {iconPosition === 'right' ? (
+          <>
+            {text}
+            {srText && <SrOnlyText srText={` ${srText}`} />}
+          </>
         ) : null}
-        {text}
-        {srText && <SrOnlyText srText={` ${srText}`} />}
-        {icon && iconPosition === 'right' ? (
+        {icon && (
           <HeroIcon
             icon={heroicon}
-            type="solid"
             aria-hidden
             className={dcnb(
               'su-inline-block',
-              levers.icon,
               levers.animate,
               levers.iconPositionStyles,
               iconClasses
             )}
             {...iProps}
           />
+        )}
+        {iconPosition === 'left' ? (
+          <>
+            {text}
+            {srText && <SrOnlyText srText={` ${srText}`} />}
+          </>
         ) : null}
       </a>
     );

--- a/src/CtaLink/CtaLink.js
+++ b/src/CtaLink/CtaLink.js
@@ -1,12 +1,14 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import { dcnb } from 'cnbuilder';
-import { ctaLinkColors } from './CtaLink.levers';
-import { iconOptions, iconAnimations } from '../common/icon/icon.levers';
-import getIconClasses from '../common/icon/getIconClasses';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { iconAlignment } from '../Button/Button.levers';
 import getIconAnimation from '../common/icon/getIconAnimation';
-import { SrOnlyText } from '../SrOnlyText/SrOnlyText';
+import getIconClasses from '../common/icon/getIconClasses';
+import getIconPosition from '../common/icon/getIconPosition';
+import { iconAnimations, iconOptions } from '../common/icon/icon.levers';
 import { HeroIcon } from '../HeroIcon/HeroIcon';
+import { SrOnlyText } from '../SrOnlyText/SrOnlyText';
+import { ctaLinkColors } from './CtaLink.levers';
 
 /**
  * CTA Link Component
@@ -14,7 +16,17 @@ import { HeroIcon } from '../HeroIcon/HeroIcon';
  */
 export const CtaLink = React.forwardRef(
   (
-    { className, text, srText, color, icon, iconProps, animate, ...props },
+    {
+      className,
+      text,
+      srText,
+      color,
+      icon,
+      iconProps,
+      iconPosition,
+      animate,
+      ...props
+    },
     ref
   ) => {
     // Defaults & Variables.
@@ -50,6 +62,7 @@ export const CtaLink = React.forwardRef(
     if (icon && iconOptions.includes(icon)) {
       heroicon = icon;
       levers.icon = getIconClasses(icon);
+      levers.iconPositionStyles = getIconPosition(icon, iconPosition);
     }
 
     // animate
@@ -73,9 +86,22 @@ export const CtaLink = React.forwardRef(
         ref={ref}
         {...props}
       >
+        {icon && iconPosition === 'left' ? (
+          <HeroIcon
+            icon={heroicon}
+            aria-hidden
+            className={dcnb(
+              'su-inline-block',
+              levers.animate,
+              levers.iconPositionStyles,
+              iconClasses
+            )}
+            {...iProps}
+          />
+        ) : null}
         {text}
         {srText && <SrOnlyText srText={` ${srText}`} />}
-        {icon && (
+        {icon && iconPosition === 'right' ? (
           <HeroIcon
             icon={heroicon}
             type="solid"
@@ -84,11 +110,12 @@ export const CtaLink = React.forwardRef(
               'su-inline-block',
               levers.icon,
               levers.animate,
+              levers.iconPositionStyles,
               iconClasses
             )}
             {...iProps}
           />
-        )}
+        ) : null}
       </a>
     );
   }
@@ -111,9 +138,14 @@ CtaLink.propTypes = {
   icon: PropTypes.oneOf(iconOptions),
 
   /**
-   * Icon options
+   * Icon Properties
    */
   iconProps: PropTypes.objectOf(PropTypes.any),
+
+  /**
+   * Icon Position options
+   */
+  iconPosition: PropTypes.oneOf(iconAlignment),
 
   /**
    * Icon animation on hover/focus
@@ -144,4 +176,5 @@ CtaLink.propTypes = {
 // -----------------------------------------------------------------------------
 CtaLink.defaultProps = {
   icon: 'action',
+  iconPosition: 'right',
 };

--- a/src/CtaLink/CtaLink.stories.js
+++ b/src/CtaLink/CtaLink.stories.js
@@ -1,8 +1,12 @@
 import React from 'react';
-import { CtaLink } from './CtaLink';
+import {
+  iconAlignment,
+  iconAnimations,
+  iconOptions,
+} from '../common/icon/icon.levers';
 import { SrOnlyText } from '../SrOnlyText/SrOnlyText';
+import { CtaLink } from './CtaLink';
 import { ctaLinkColors } from './CtaLink.levers';
-import { iconOptions, iconAnimations } from '../common/icon/icon.levers';
 
 export default {
   title: 'Simple/CTA Link',
@@ -25,6 +29,12 @@ export default {
       control: {
         type: 'inline-radio',
         options: iconAnimations,
+      },
+    },
+    iconPosition: {
+      control: {
+        type: 'select',
+        options: iconAlignment,
       },
     },
   },

--- a/src/CtaLink/CtaLink.stories.js
+++ b/src/CtaLink/CtaLink.stories.js
@@ -33,7 +33,7 @@ export default {
     },
     iconPosition: {
       control: {
-        type: 'select',
+        type: 'inline-radio',
         options: iconAlignment,
       },
     },

--- a/src/HeroIcon/HeroIcon.js
+++ b/src/HeroIcon/HeroIcon.js
@@ -12,6 +12,8 @@ import {
   LockClosedIcon,
   MailIcon,
   PlayIcon,
+  UploadIcon,
+  XIcon,
 } from '@heroicons/react/solid';
 import { dcnb } from 'cnbuilder';
 import PropTypes from 'prop-types';
@@ -56,6 +58,10 @@ export const HeroIcon = ({ icon, srText, className, ...props }) => {
         Icon = DownloadIcon;
         break;
 
+      case 'upload':
+        Icon = UploadIcon;
+        break;
+
       case 'email':
         Icon = MailIcon;
         break;
@@ -68,6 +74,10 @@ export const HeroIcon = ({ icon, srText, className, ...props }) => {
       case 'chevron-right':
       case 'action':
         Icon = ChevronRightIcon;
+        break;
+
+      case 'close':
+        Icon = XIcon;
         break;
 
       case 'lock':

--- a/src/common/icon/getIconAnimation.js
+++ b/src/common/icon/getIconAnimation.js
@@ -25,6 +25,10 @@ const getIconAnimation = (animate) => {
       classes = dcnb(classes, 'group-hocus:su-translate-y-02em');
       break;
 
+    case 'up':
+      classes = dcnb(classes, 'group-hocus:su--translate-y-02em');
+      break;
+
     case 'right':
       classes = dcnb(classes, 'group-hocus:su-translate-x-02em');
       break;

--- a/src/common/icon/getIconClasses.js
+++ b/src/common/icon/getIconClasses.js
@@ -16,9 +16,8 @@ const getIconClasses = (icon) => {
       break;
 
     case 'lock':
-      classes = 'su-h-08em su-w-08em su--mt-3';
-      break;
-
+    case 'close':
+    case 'upload':
     case 'download':
       classes = 'su-h-08em su-w-08em su--mt-3';
       break;

--- a/src/common/icon/getIconClasses.js
+++ b/src/common/icon/getIconClasses.js
@@ -8,47 +8,47 @@ const getIconClasses = (icon) => {
 
   switch (icon) {
     case 'more':
-      classes = 'su-h-09em su-w-09em su-ml-5 su--mt-2';
+      classes = 'su-h-09em su-w-09em su--mt-2';
       break;
 
     case 'external':
-      classes = 'su-w-08em su-ml-02em su--rotate-45 group-hocus:su--rotate-45';
+      classes = 'su-w-08em su--rotate-45 group-hocus:su--rotate-45';
       break;
 
     case 'lock':
-      classes = 'su-h-08em su-w-08em su-ml-4 su--mt-3';
+      classes = 'su-h-08em su-w-08em su--mt-3';
       break;
 
     case 'download':
-      classes = 'su-h-08em su-w-08em su-ml-4 su--mt-3';
+      classes = 'su-h-08em su-w-08em su--mt-3';
       break;
 
     case 'play':
-      classes = 'su-w-08em su-ml-7 su--mt-3';
+      classes = 'su-w-08em su--mt-3';
       break;
 
     case 'podcast':
-      classes = 'su-w-08em su-mt-[-0.25em] su-ml-4';
+      classes = 'su-w-08em su-mt-[-0.25em]';
       break;
 
     case 'video':
-      classes = 'su-h-08em su-w-08em su-ml-6 su--mt-3';
+      classes = 'su-h-08em su-w-08em su--mt-3';
       break;
 
     case 'email':
-      classes = 'su-h-08em su-w-08em su-ml-7 su--mt-2';
+      classes = 'su-h-08em su-w-08em su--mt-2';
       break;
 
     case 'jump':
-      classes = 'su-h-1em su-w-1em su-ml-4 su--mt-2';
+      classes = 'su-h-1em su-w-1em su--mt-2';
       break;
 
     case 'action':
-      classes = 'su-h-1em su-w-1em su-ml-4 su--mt-2';
+      classes = 'su-h-1em su-w-1em su--mt-2';
       break;
 
     case 'info':
-      classes = 'su-h-1em su-w-1em su-ml-4 su--mt-2';
+      classes = 'su-h-1em su-w-1em su--mt-2';
       break;
 
     default:

--- a/src/common/icon/getIconPosition.js
+++ b/src/common/icon/getIconPosition.js
@@ -18,10 +18,12 @@ const getIconPosition = (icon, position) => {
 
       case 'lock':
       case 'download':
+      case 'upload':
         classes = 'su-ml-4';
         break;
 
       case 'play':
+      case 'close':
         classes = 'su-ml-7';
         break;
 
@@ -59,10 +61,12 @@ const getIconPosition = (icon, position) => {
 
       case 'lock':
       case 'download':
+      case 'upload':
         classes = 'su-mr-4';
         break;
 
       case 'play':
+      case 'close':
         classes = 'su-mr-7';
         break;
 

--- a/src/common/icon/getIconPosition.js
+++ b/src/common/icon/getIconPosition.js
@@ -1,0 +1,95 @@
+/**
+ * Retrieve group of classes for finetuning CTA icon position spacing
+ *
+ */
+
+const getIconPosition = (icon, position) => {
+  let classes = '';
+
+  if (position === 'right') {
+    switch (icon) {
+      case 'more':
+        classes = 'su-ml-5';
+        break;
+
+      case 'external':
+        classes = 'su-ml-02em';
+        break;
+
+      case 'lock':
+      case 'download':
+        classes = 'su-ml-4';
+        break;
+
+      case 'play':
+        classes = 'su-ml-7';
+        break;
+
+      case 'podcast':
+        classes = 'su-ml-4';
+        break;
+
+      case 'video':
+        classes = 'su-ml-6';
+        break;
+
+      case 'email':
+        classes = 'su-ml-7';
+        break;
+
+      case 'jump':
+      case 'action':
+      case 'info':
+        classes = 'su-ml-4';
+        break;
+
+      default:
+      // None.
+    }
+  }
+  if (position === 'left') {
+    switch (icon) {
+      case 'more':
+        classes = 'su-mr-5';
+        break;
+
+      case 'external':
+        classes = 'su-mr-02em';
+        break;
+
+      case 'lock':
+      case 'download':
+        classes = 'su-mr-4';
+        break;
+
+      case 'play':
+        classes = 'su-mr-7';
+        break;
+
+      case 'podcast':
+        classes = 'su-mr-4';
+        break;
+
+      case 'video':
+        classes = 'su-mr-6';
+        break;
+
+      case 'email':
+        classes = 'su-mr-7';
+        break;
+
+      case 'jump':
+      case 'action':
+      case 'info':
+        classes = 'su-mr-4';
+        break;
+
+      default:
+      // None.
+    }
+  }
+
+  return classes;
+};
+
+export default getIconPosition;

--- a/src/common/icon/icon.levers.js
+++ b/src/common/icon/icon.levers.js
@@ -15,13 +15,15 @@ export const iconOptions = [
   'jump',
   'email',
   'info',
+  'upload',
+  'close',
   'none',
 ];
 
 /**
  * CTA Icon animation options
  */
-export const iconAnimations = ['right', 'top-right', 'down', 'none'];
+export const iconAnimations = ['right', 'top-right', 'down', 'up', 'none'];
 
 /**
  * Icon alignment

--- a/src/common/icon/icon.levers.js
+++ b/src/common/icon/icon.levers.js
@@ -22,3 +22,8 @@ export const iconOptions = [
  * CTA Icon animation options
  */
 export const iconAnimations = ['right', 'top-right', 'down', 'none'];
+
+/**
+ * Icon alignment
+ */
+export const iconAlignment = ['left', 'right'];


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add icon alignment/position options to Buttons, Cta Buttons, and Cta Links.
- Add X and Upload Icons.
- Add Up icon animation

# Needed By (Date)
- tbd

# Urgency
- medium

# Steps to Test

1. Pull this PR and review locally or on Netlify
-  Button: `/story/simple-button--email` || [Netlify](https://deploy-preview-82--decanter-react.netlify.app/?path=/story/simple-button--email)
- Cta Button: `/story/simple-cta-link-button--action` || [Netlify](https://deploy-preview-82--decanter-react.netlify.app/?path=/story/simple-cta-link-button--action)
- Cta Link: `/story/simple-cta-link--email&args=iconPosition:left` || [Netlify](https://deploy-preview-82--decanter-react.netlify.app/?path=/story/simple-cta-link--email&args=iconPosition:left)

2. Check to see that the icons properly align left and right.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- [ADAPT-3762](https://stanfordits.atlassian.net/browse/ADAPT-3762)
- [ADAPT-3820](https://stanfordits.atlassian.net/browse/ADAPT-3820)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
